### PR TITLE
Update runner dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
 
   build:
     name: Build from OpenVINO source
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:
@@ -31,7 +31,7 @@ jobs:
     - name: Checkout LFS obects
       run: git lfs checkout
     - name: Install system dependencies
-      run: sudo apt update && sudo apt install -y clang cmake libclang-dev gnupg2 libdrm2 libglib2.0-0 libusb-1.0 lsb-release libgtk-3-0 libtool libopencv-dev libopencv-core3.2 udev unzip dos2unix
+      run: sudo apt update && sudo apt install -y clang cmake libclang-dev gnupg2 libdrm2 libglib2.0-0 libusb-1.0-0-dev lsb-release libgtk-3-0 libtool libopencv-dev libopencv-core4.2 udev unzip dos2unix
     - name: Build (openvino-sys from source)
       run: cargo build --verbose
     - name: Run tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -280,12 +280,13 @@ checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
 name = "opencv"
-version = "0.45.1"
+version = "0.49.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc1ee7209d4811b6e45bcffaf69136d6eaa97c333f260da5d3b9646f1b61119"
+checksum = "7af7570b5a4cc0a6cbc003a46bbe7cf586bc01d4024442bcf735d56d5007394b"
 dependencies = [
  "cc",
  "clang",
+ "dunce",
  "glob",
  "jobserver",
  "libc",
@@ -300,9 +301,9 @@ dependencies = [
 
 [[package]]
 name = "opencv-binding-generator"
-version = "0.20.0"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b3db96e062ec0454cda1d05fb1404864a7566589aa78a0b17311805063ad704"
+checksum = "b103afeab0c96624c28ced967ad96601601717c1a0a5bbe03ddb6efbb9a7e50b"
 dependencies = [
  "clang",
  "clang-sys",
@@ -351,6 +352,15 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pest"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
+dependencies = [
+ "ucd-trie",
+]
 
 [[package]]
 name = "pkg-config"
@@ -442,18 +452,21 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "semver"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "394cec28fa623e00903caf7ba4fa6fb9a0e260280bb8cdbbba029611108a0190"
+checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
  "semver-parser",
 ]
 
 [[package]]
 name = "semver-parser"
-version = "0.7.0"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
+checksum = "00b0bef5b7f9e0df16536d3961cfb6e84331c065b4066afb39768d0e319411f7"
+dependencies = [
+ "pest",
+]
 
 [[package]]
 name = "shlex"
@@ -548,6 +561,12 @@ checksum = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56dee185309b50d1f11bfedef0fe6d036842e3fb77413abef29f8f8d1c5d4c1c"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This Dockerfile demonstrates how to build the openvino bindings using an installation of OpenVINO. For instructions
 # to install OpenVINO see the OpenVINO documentation, e.g.
 # https://docs.openvinotoolkit.org/latest/openvino_docs_install_guides_installing_openvino_apt.html.
-FROM rust:1.45
+FROM rust:1.50
 
 # Setup Rust.
 RUN rustup component add rustfmt
@@ -25,6 +25,9 @@ RUN apt install -y libopencv-dev libopencv-core3.2
 # Copy in OpenVINO source
 WORKDIR /usr/src/openvino
 COPY . .
+
+# Hack to allow the opencv crate to build with an older version of the OpenCV libraries (FIXME).
+RUN sed -i 's/"opencv-4"/"opencv-32"/g' crates/openvino-tensor-converter/Cargo.toml
 
 # Build openvino libraries.
 WORKDIR /usr/src/openvino/inference-engine/ie_bridges/rust

--- a/crates/openvino-sys/build.rs
+++ b/crates/openvino-sys/build.rs
@@ -189,8 +189,12 @@ fn build_from_source_using_cmake() -> Vec<PathBuf> {
             .define("NGRAPH_ONNX_IMPORT_ENABLE", "ON")
             .define("ENABLE_OPENCV", "OFF")
             .define("ENABLE_CPPLINT", "OFF")
-            // Because OpenVINO by default wants to build its binaries in its own tree, we must specify
-            // that we actually want them in Cargo's output directory.
+            // As described in https://github.com/intel/openvino-rs/issues/8, the OpenVINO source
+            // includes redundant moves. These were previously warnings but newer compilers treat
+            // them as errors.
+            .cxxflag("-Wno-error=redundant-move")
+            // Because OpenVINO by default wants to build its binaries in its own tree, we must
+            // specify that we actually want them in Cargo's output directory.
             .define("OUTPUT_ROOT", out_dir);
         config
     }

--- a/crates/openvino-tensor-converter/Cargo.toml
+++ b/crates/openvino-tensor-converter/Cargo.toml
@@ -9,5 +9,6 @@ publish = false
 log = "0.4"
 pretty_env_logger = "0.4"
 structopt = { version = "0.3", default-features = false }
-# Note: the features below are very system-specific, see https://github.com/twistedfall/opencv-rust.
-opencv = {version = "0.45", default-features = false, features = ["opencv-32", "buildtime-bindgen", "clang-runtime"]}
+# Note: by default this will attempt to find a 4.x version of OpenCV libraries (e.g.
+# `libopencv-dev`).
+opencv = {version = "0.49", default-features = false, features = ["opencv-4", "buildtime-bindgen", "clang-runtime"]}


### PR DESCRIPTION
GitHub's `ubuntu-latest` runner uses Ubuntu 20.04 whereas previously it used Ubuntu 18.04. As a result, several dependencies must change
 - libusb has a different name
 - opencv uses the 4.x branch (previously 3.2)