### PR TITLE
Only export the inference engine functions in openvino-sys 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,13 +37,12 @@ checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "bindgen"
-version = "0.55.1"
+version = "0.58.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b13ce559e6433d360c26305643803cb52cfbabbc2b9c47ce04a58493dfb443"
+checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
 dependencies = [
  "bitflags",
  "cexpr",
- "cfg-if",
  "clang-sys",
  "clap",
  "env_logger",
@@ -114,18 +113,18 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e56268c17a6248366d66d4a47a3381369d068cce8409bb1716ed77ea32163bb"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
  "humantime",
@@ -160,12 +159,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "lazy_static"
@@ -262,12 +258,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,9 +292,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "shlex"
-version = "0.1.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fdf1b9db47230893d76faad238fd6097fd6d6a9245cd7a4d90dbd639536bbd2"
+checksum = "42a568c8f2cd051a4d283bd6eb0343ac214c1b0f1ac19f93e1175b2dee38c73d"
 
 [[package]]
 name = "strsim"

--- a/crates/openvino-sys/Cargo.toml
+++ b/crates/openvino-sys/Cargo.toml
@@ -21,8 +21,8 @@ include = [
 ]
 
 [build-dependencies]
-bindgen = "0.55.1"
-cmake = "0.1.44"
+bindgen = "0.58.1"
+cmake = "0.1.45"
 
 [features]
 default = ["cpu"]

--- a/crates/openvino-sys/build.rs
+++ b/crates/openvino-sys/build.rs
@@ -36,6 +36,10 @@ fn main() {
         file("upstream/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h");
     let bindings = bindgen::Builder::default()
         .header(openvino_c_api_header.to_string_lossy())
+        .allowlist_function("ie_.*")
+        .blocklist_type("__uint8_t")
+        .blocklist_type("__int64_t")
+        .size_t_is_usize(true)
         // While understanding the warnings in https://docs.rs/bindgen/0.36.0/bindgen/struct.Builder.html#method.rustified_enum
         // that these enums could result in unspecified behavior if constructed from an invalid
         // value, the expectation here is that OpenVINO only returns valid layout and precision
@@ -43,6 +47,7 @@ fn main() {
         .rustified_enum("layout_e")
         .rustified_enum("precision_e")
         .rustified_enum("resize_alg_e")
+        .rustified_enum("colorformat_e")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
         .generate()
         .expect("generate C API bindings");

--- a/crates/openvino/src/core.rs
+++ b/crates/openvino/src/core.rs
@@ -56,13 +56,12 @@ impl Core {
         weights_content: &[u8],
     ) -> Result<CNNNetwork> {
         let mut instance = std::ptr::null_mut();
-        let weights_desc =
-            TensorDesc::new(Layout::ANY, &[weights_content.len() as u64], Precision::U8);
+        let weights_desc = TensorDesc::new(Layout::ANY, &[weights_content.len()], Precision::U8);
         let weights_blob = Blob::new(weights_desc, weights_content)?;
         try_unsafe!(ie_core_read_network_from_memory(
             self.instance,
             model_content as *const _ as *const u8,
-            model_content.len() as u64,
+            model_content.len(),
             weights_blob.instance,
             &mut instance as *mut *mut _,
         ))?;

--- a/crates/openvino/src/network.rs
+++ b/crates/openvino/src/network.rs
@@ -24,7 +24,7 @@ impl CNNNetwork {
         let mut cname = std::ptr::null_mut();
         try_unsafe!(ie_network_get_input_name(
             self.instance,
-            index as u64,
+            index,
             &mut cname as *mut *mut _
         ))?;
         let name = unsafe { CStr::from_ptr(cname) }
@@ -40,7 +40,7 @@ impl CNNNetwork {
         let mut cname = std::ptr::null_mut();
         try_unsafe!(ie_network_get_output_name(
             self.instance,
-            index as u64,
+            index,
             &mut cname as *mut *mut _
         ))?;
         let name = unsafe { CStr::from_ptr(cname) }

--- a/crates/openvino/src/request.rs
+++ b/crates/openvino/src/request.rs
@@ -14,7 +14,7 @@ drop_using_function!(InferRequest, ie_infer_request_free);
 impl InferRequest {
     /// Set the batch size of the inference requests.
     pub fn set_batch_size(&mut self, size: usize) -> Result<()> {
-        try_unsafe!(ie_infer_request_set_batch(self.instance, size as u64))
+        try_unsafe!(ie_infer_request_set_batch(self.instance, size))
     }
 
     /// Assign a [Blob] to the input (i.e. `name`) on the network.

--- a/crates/openvino/src/tensor_desc.rs
+++ b/crates/openvino/src/tensor_desc.rs
@@ -8,7 +8,7 @@ pub struct TensorDesc {
 
 impl TensorDesc {
     /// Construct a new [TensorDesc] from its C API components.
-    pub fn new(layout: Layout, dimensions: &[u64], precision: Precision) -> Self {
+    pub fn new(layout: Layout, dimensions: &[usize], precision: Precision) -> Self {
         // Setup dimensions.
         assert!(dimensions.len() < 8);
         let mut dims = [0; 8];
@@ -19,7 +19,7 @@ impl TensorDesc {
             instance: tensor_desc_t {
                 layout,
                 dims: dimensions_t {
-                    ranks: dimensions.len() as u64,
+                    ranks: dimensions.len(),
                     dims,
                 },
                 precision,


### PR DESCRIPTION
Previously, many libc types and functions were exported by openvino-sys (and visible in docs.rs). This change tightens up rust-bindgen to only emit the `ie_*` functions (and their recursively-used types, a default setting). It also eliminates some `__uint8_t` and `__int64_t` as well as properly transforming `size_t` to `usize`.