### PR TITLE
More runtime-linking changes

### DIFF
--- a/crates/openvino-finder/README.md
+++ b/crates/openvino-finder/README.md
@@ -1,7 +1,15 @@
 openvino-finder
 ===============
 
-A utility for locating OpenVINO™ libraries on a host system.
+A utility for locating OpenVINO™ libraries on a host system. It will attempt to find the OpenVINO
+shared libraries in:
+- the `OPENVINO_INSTALL_DIR` environment variable (pointed at the top-level OpenVINO installation,
+  e.g. `/opt/intel/openvino`)
+- the `INTEL_OPENVINO_DIR` environment variable (same as above; this is set by OpenVINO setup
+  scripts)
+- the environment's library path (e.g., `LD_LIBRARY_PATH` in Linux; this is also set by the OpenVINO
+  setup scripts)
+- OpenVINO's default installation paths for the OS (a best effort attempt)
 
 > #### WARNING
 > This crate is currently experimental--its API surface is subject to change.

--- a/crates/openvino/Cargo.toml
+++ b/crates/openvino/Cargo.toml
@@ -18,3 +18,6 @@ thiserror = "1.0.20"
 
 [dev-dependencies]
 float-cmp = "0.8"
+
+[features]
+runtime-linking = ["openvino-sys/runtime-linking"]

--- a/crates/openvino/src/error.rs
+++ b/crates/openvino/src/error.rs
@@ -1,12 +1,8 @@
 use thiserror::Error;
 
-/// See
+/// Enumerate errors returned by the OpenVINO implementation. See
 /// [IEStatusCode](https://docs.openvinotoolkit.org/latest/ie_c_api/ie__c__api_8h.html#a391683b1e8e26df8b58d7033edd9ee83).
-///
-/// TODO Replace this in bindgen with
-/// [newtype_enum](https://docs.rs/bindgen/0.54.1/bindgen/struct.Builder.html#method.newtype_enum)
-/// or
-/// [rustified_enum](https://docs.rs/bindgen/0.54.1/bindgen/struct.Builder.html#method.rustified_enum).
+/// TODO This could be auto-generated (https://github.com/intel/openvino-rs/issues/20).
 #[derive(Debug, Error)]
 pub enum InferenceError {
     #[error("general error")]
@@ -57,4 +53,26 @@ impl InferenceError {
             _ => Err(Undefined(error_code)),
         }
     }
+}
+
+/// Enumberate setup failures: in some cases, this library calls library loading code that may fail
+/// in a different way (i.e., [LoadingError]) than the calls in to the OpenVINO libraries (i.e.,
+/// [InferenceError]).
+#[derive(Debug, Error)]
+pub enum SetupError {
+    #[error("inference error")]
+    Inference(#[from] InferenceError),
+    #[error("library loading error")]
+    Loading(#[from] LoadingError),
+}
+
+/// Enumerate the ways that library loading can fail.
+#[derive(Debug, Error)]
+pub enum LoadingError {
+    #[error("system failed to load shared libraries (see https://github.com/intel/openvino-rs/blob/main/crates/openvino-finder): {0}")]
+    SystemFailure(String),
+    #[error("cannot find path to shared libraries (see https://github.com/intel/openvino-rs/blob/main/crates/openvino-finder)")]
+    CannotFindPath,
+    #[error("no parent directory found for shared library path")]
+    NoParentDirectory,
 }

--- a/crates/openvino/src/lib.rs
+++ b/crates/openvino/src/lib.rs
@@ -8,7 +8,7 @@ mod util;
 
 pub use crate::core::Core;
 pub use blob::Blob;
-pub use error::InferenceError;
+pub use error::{InferenceError, LoadingError, SetupError};
 pub use network::{CNNNetwork, ExecutableNetwork};
 // Re-publish some OpenVINO enums with a conventional Rust naming (see
 // `crates/openvino-sys/build.rs`).


### PR DESCRIPTION
While integrating with external libraries, the changes in this PR became apparent:
 - I needed a way to turn on the `runtime-linking` feature when `openvino` was imported as a Cargo dependency
 - and I needed a way to return errors instead of panicking when library loading fails.