### PR TITLE
openvino-finder: add logging, OPENVINO_BUILD_DIR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,10 @@ jobs:
     - name: Build (openvino-sys from source)
       run: cargo build --verbose --features openvino-sys/from-source
     - name: Run tests
-      run: cargo test --verbose --features openvino-sys/from-source
+      # For some reason the library path is not set during the doc tests (`--doc`, see
+      # https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection) so we skip them
+      # here: issue at https://github.com/intel/openvino-rs/issues/25.
+      run: cargo test --verbose --features openvino-sys/from-source --lib --tests
 
   # Build and test from an existing OpenVINO installation inside a Docker image (i.e. download the
   # binaries, then compile against these).

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "crates/upstream"]
 	path = crates/openvino-sys/upstream
 	url = https://github.com/openvinotoolkit/openvino
+	depth = 1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -275,6 +275,7 @@ dependencies = [
 name = "openvino-finder"
 version = "0.3.1"
 dependencies = [
+ "cfg-if",
  "log",
  "pretty_env_logger",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,7 +51,7 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "clap",
- "env_logger",
+ "env_logger 0.8.3",
  "lazy_static",
  "lazycell",
  "log",
@@ -128,12 +128,25 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime 1.3.0",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17392a012ea30ef05a610aa97dfb49496e71c9f676b27879922ea5bdf60d9d3f"
 dependencies = [
  "atty",
- "humantime",
+ "humantime 2.1.0",
  "log",
  "regex",
  "termcolor",
@@ -170,6 +183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
 ]
 
 [[package]]
@@ -252,6 +274,10 @@ dependencies = [
 [[package]]
 name = "openvino-finder"
 version = "0.3.1"
+dependencies = [
+ "log",
+ "pretty_env_logger",
+]
 
 [[package]]
 name = "openvino-sys"
@@ -276,6 +302,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10f4872ae94d7b90ae48754df22fd42ad52ce740b8f370b03da4835417403e53"
 dependencies = [
  "ucd-trie",
+]
+
+[[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger 0.7.1",
+ "log",
 ]
 
 [[package]]
@@ -310,6 +346,12 @@ checksum = "175c513d55719db99da20232b06cda8bab6b83ec2d04e3283edf0213c37c1a29"
 dependencies = [
  "unicode-xid",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"

--- a/crates/openvino-finder/Cargo.toml
+++ b/crates/openvino-finder/Cargo.toml
@@ -10,3 +10,7 @@ documentation = "https://docs.rs/openvino-finder"
 edition = "2018"
 
 [dependencies]
+log = "0.4"
+
+[dev-dependencies]
+pretty_env_logger = "0.4"

--- a/crates/openvino-finder/Cargo.toml
+++ b/crates/openvino-finder/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/openvino-finder"
 edition = "2018"
 
 [dependencies]
+cfg-if = "1.0"
 log = "0.4"
 
 [dev-dependencies]

--- a/crates/openvino-finder/src/lib.rs
+++ b/crates/openvino-finder/src/lib.rs
@@ -1,3 +1,4 @@
+use cfg_if::cfg_if;
 use std::env;
 use std::path::PathBuf;
 
@@ -85,21 +86,32 @@ const ENV_OPENVINO_INSTALL_DIR: &'static str = "OPENVINO_INSTALL_DIR";
 const ENV_OPENVINO_BUILD_DIR: &'static str = "OPENVINO_BUILD_DIR";
 const ENV_INTEL_OPENVINO_DIR: &'static str = "INTEL_OPENVINO_DIR";
 
-#[cfg(target_os = "linux")]
-const ENV_LIBRARY_PATH: &'static str = "LD_LIBRARY_PATH";
-#[cfg(target_os = "macos")]
-const ENV_LIBRARY_PATH: &'static str = "DYLD_LIBRARY_PATH";
-#[cfg(target_os = "windows")]
-const ENV_LIBRARY_PATH: &'static str = "PATH";
+cfg_if! {
+    if #[cfg(any(target_os = "linux"))] {
+        const ENV_LIBRARY_PATH: &'static str = "LD_LIBRARY_PATH";
+    } else if #[cfg(target_os = "macos")] {
+        const ENV_LIBRARY_PATH: &'static str = "DYLD_LIBRARY_PATH";
+    } else if #[cfg(target_os = "windows")] {
+        const ENV_LIBRARY_PATH: &'static str = "PATH";
+    } else {
+        // This may not work but seems like a sane default for target OS' not listed above.
+        const ENV_LIBRARY_PATH: &'static str = "LD_LIBRARY_PATH";
+    }
+}
 
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-const DEFAULT_INSTALLATION_DIRECTORIES: &'static [&'static str] =
-    &["/opt/intel/openvino", "/opt/intel/openvino_2021"];
-#[cfg(target_os = "windows")]
-const DEFAULT_INSTALLATION_DIRECTORIES: &'static [&'static str] = &[
-    "C:\\Program Files (x86)\\Intel\\openvino",
-    "C:\\Program Files (x86)\\Intel\\openvino_2021",
-];
+cfg_if! {
+    if #[cfg(any(target_os = "linux", target_os = "macos"))] {
+        const DEFAULT_INSTALLATION_DIRECTORIES: &'static [&'static str] =
+            &["/opt/intel/openvino", "/opt/intel/openvino_2021"];
+    } else if #[cfg(target_os = "windows")] {
+        const DEFAULT_INSTALLATION_DIRECTORIES: &'static [&'static str] = &[
+            "C:\\Program Files (x86)\\Intel\\openvino",
+            "C:\\Program Files (x86)\\Intel\\openvino_2021",
+        ];
+    } else {
+        const DEFAULT_INSTALLATION_DIRECTORIES: &'static [&'static str] = &[];
+    }
+}
 
 const KNOWN_INSTALLATION_SUBDIRECTORIES: &'static [&'static str] = &[
     "deployment_tools/ngraph/lib",


### PR DESCRIPTION
Also, provides sane defaults for unsupported target OS combinations to avoid build failures and fixes the `from-source` build failures.