### PR TITLE
openvino: add Cargo features exposing openvino-sys features

### DIFF
--- a/crates/openvino/Cargo.toml
+++ b/crates/openvino/Cargo.toml
@@ -21,6 +21,8 @@ float-cmp = "0.8"
 
 [features]
 runtime-linking = ["openvino-sys/runtime-linking"]
+from-source = ["openvino-sys/from-source"]
+all = ["openvino-sys/all"]
 
 [package.metadata.docs.rs]
 features = ["runtime-linking"]


### PR DESCRIPTION
Since it is unclear to me when it is possible to modify features of sub-dependencies, it seemed good to be able to access some of the features of the underlying dependency, `openvino-sys`.