### PR TITLE
Add `get_[inputs|outputs]_len` to `CNNNetwork`

### DIFF
--- a/crates/openvino/src/error.rs
+++ b/crates/openvino/src/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 /// Enumerate errors returned by the OpenVINO implementation. See
 /// [IEStatusCode](https://docs.openvinotoolkit.org/latest/ie_c_api/ie__c__api_8h.html#a391683b1e8e26df8b58d7033edd9ee83).
 /// TODO This could be auto-generated (https://github.com/intel/openvino-rs/issues/20).
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum InferenceError {
     #[error("general error")]
     GeneralError,

--- a/crates/openvino/tests/setup.rs
+++ b/crates/openvino/tests/setup.rs
@@ -10,5 +10,9 @@ fn read_network() {
     let mut core = Core::new(None).unwrap();
     let model = fs::read(Fixture::graph()).unwrap();
     let weights = fs::read(Fixture::weights()).unwrap();
-    core.read_network_from_buffer(&model, &weights).unwrap();
+    let network = core.read_network_from_buffer(&model, &weights).unwrap();
+
+    // Check the number of inputs and outputs.
+    assert_eq!(network.get_inputs_len(), Ok(1));
+    assert_eq!(network.get_outputs_len(), Ok(1));
 }


### PR DESCRIPTION
This change is an adaptation of #33 that allows for the same kind of functionality. It also adds tests checking the newly-added functions. With this in place, users will be able to set input layouts with something like:

```rust
for i in 0..network.get_inputs_len() {
  let name = network.get_input_name(i)?;
  network.set_input_layout(&name, Layout::NHWC)?;
}
```