### PR TITLE
Add `cargo clippy` and `cargo deny` scans to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,13 @@ jobs:
     - run: cargo clippy --features runtime-linking
     - run: cd crates/openvino-tensor-converter && cargo fmt --all -- --check
 
+  rust_dependencies:
+    name: Check Rust dependencies
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: EmbarkStudios/cargo-deny-action@v1
+
   # Build and test from the git-submodule-included OpenVINO source code.
   source:
     name: From source

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,12 @@ jobs:
         submodules: true
     - run: rustup component add rustfmt
     - run: cargo fmt --all -- --check
+    # Use the `runtime-linking` feature here to avoid requiring an OpenVINO installation to be
+    # present when building.
+    - run: cargo clippy --features runtime-linking
     - run: cd crates/openvino-tensor-converter && cargo fmt --all -- --check
 
-  # Build and test from the git-submodule-included OpenVINO source code. 
+  # Build and test from the git-submodule-included OpenVINO source code.
   source:
     name: From source
     runs-on: ubuntu-20.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "nom"
@@ -367,9 +367,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.5"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -378,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.23"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rustc-hash"

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+doc-valid-idents = ["OpenVINO"]

--- a/crates/openvino-finder/Cargo.toml
+++ b/crates/openvino-finder/Cargo.toml
@@ -7,6 +7,8 @@ readme = "README.md"
 authors = ["OpenVINO Project Developers"]
 repository = "https://github.com/intel/openvino-rs"
 documentation = "https://docs.rs/openvino-finder"
+keywords = ["openvino", "machine-learning", "ml", "neural-network"]
+categories = ["development-tools"]
 edition = "2018"
 
 [dependencies]

--- a/crates/openvino-finder/src/lib.rs
+++ b/crates/openvino-finder/src/lib.rs
@@ -1,3 +1,11 @@
+//! Provides a mechanism for locating the OpenVINO shared libraries installed on a system.
+
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(clippy::must_use_candidate)]
+
 use cfg_if::cfg_if;
 use std::env;
 use std::path::PathBuf;
@@ -82,38 +90,38 @@ pub fn find(library_name: &str) -> Option<PathBuf> {
     None
 }
 
-const ENV_OPENVINO_INSTALL_DIR: &'static str = "OPENVINO_INSTALL_DIR";
-const ENV_OPENVINO_BUILD_DIR: &'static str = "OPENVINO_BUILD_DIR";
-const ENV_INTEL_OPENVINO_DIR: &'static str = "INTEL_OPENVINO_DIR";
+const ENV_OPENVINO_INSTALL_DIR: &str = "OPENVINO_INSTALL_DIR";
+const ENV_OPENVINO_BUILD_DIR: &str = "OPENVINO_BUILD_DIR";
+const ENV_INTEL_OPENVINO_DIR: &str = "INTEL_OPENVINO_DIR";
 
 cfg_if! {
     if #[cfg(any(target_os = "linux"))] {
-        const ENV_LIBRARY_PATH: &'static str = "LD_LIBRARY_PATH";
+        const ENV_LIBRARY_PATH: &str = "LD_LIBRARY_PATH";
     } else if #[cfg(target_os = "macos")] {
-        const ENV_LIBRARY_PATH: &'static str = "DYLD_LIBRARY_PATH";
+        const ENV_LIBRARY_PATH: &str = "DYLD_LIBRARY_PATH";
     } else if #[cfg(target_os = "windows")] {
-        const ENV_LIBRARY_PATH: &'static str = "PATH";
+        const ENV_LIBRARY_PATH: &str = "PATH";
     } else {
         // This may not work but seems like a sane default for target OS' not listed above.
-        const ENV_LIBRARY_PATH: &'static str = "LD_LIBRARY_PATH";
+        const ENV_LIBRARY_PATH: &str = "LD_LIBRARY_PATH";
     }
 }
 
 cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "macos"))] {
-        const DEFAULT_INSTALLATION_DIRECTORIES: &'static [&'static str] =
+        const DEFAULT_INSTALLATION_DIRECTORIES: & [& str] =
             &["/opt/intel/openvino_2021", "/opt/intel/openvino"];
     } else if #[cfg(target_os = "windows")] {
-        const DEFAULT_INSTALLATION_DIRECTORIES: &'static [&'static str] = &[
+        const DEFAULT_INSTALLATION_DIRECTORIES: & [& str] = &[
             "C:\\Program Files (x86)\\Intel\\openvino",
             "C:\\Program Files (x86)\\Intel\\openvino_2021",
         ];
     } else {
-        const DEFAULT_INSTALLATION_DIRECTORIES: &'static [&'static str] = &[];
+        const DEFAULT_INSTALLATION_DIRECTORIES: & [& str] = &[];
     }
 }
 
-const KNOWN_INSTALLATION_SUBDIRECTORIES: &'static [&'static str] = &[
+const KNOWN_INSTALLATION_SUBDIRECTORIES: &[&str] = &[
     "deployment_tools/ngraph/lib",
     "deployment_tools/inference_engine/lib/intel64",
     "deployment_tools/inference_engine/external/hddl/lib",
@@ -121,7 +129,7 @@ const KNOWN_INSTALLATION_SUBDIRECTORIES: &'static [&'static str] = &[
     "deployment_tools/inference_engine/external/tbb/lib",
 ];
 
-const KNOWN_BUILD_SUBDIRECTORIES: &'static [&'static str] = &[
+const KNOWN_BUILD_SUBDIRECTORIES: &[&str] = &[
     "bin/intel64/Debug/lib",
     "bin/intel64/Release/lib",
     "inference-engine/temp/tbb/lib",

--- a/crates/openvino-sys/Cargo.toml
+++ b/crates/openvino-sys/Cargo.toml
@@ -7,6 +7,8 @@ readme = "README.md"
 authors = ["OpenVINO Project Developers"]
 repository = "https://github.com/intel/openvino-rs"
 documentation = "https://docs.rs/openvino-sys"
+keywords = ["external-ffi-bindings", "openvino", "machine-learning", "ml", "neural-network"]
+categories = ["external-ffi-bindings", "science"]
 edition = "2018"
 include = [
     "/Cargo.toml",

--- a/crates/openvino-sys/build.rs
+++ b/crates/openvino-sys/build.rs
@@ -1,9 +1,8 @@
-use cmake;
 use std::env;
 use std::path::{Path, PathBuf};
 
 // These are the libraries we expect to be available to dynamically link to:
-const LIBRARIES: &'static [&'static str] = &[
+const LIBRARIES: &[&str] = &[
     "inference_engine",
     "inference_engine_legacy",
     "inference_engine_transformations",
@@ -14,11 +13,11 @@ const LIBRARIES: &'static [&'static str] = &[
 
 // A user-specified environment variable indicating that `build.rs` should not attempt to link
 // against any libraries (e.g. a doc build, user may link them later).
-const ENV_OPENVINO_SKIP_LINKING: &'static str = "OPENVINO_SKIP_LINKING";
+const ENV_OPENVINO_SKIP_LINKING: &str = "OPENVINO_SKIP_LINKING";
 
 // A build.rs-specified environment variable that must be populated with the location of the
 // inference engine library that OpenVINO is being linked to in this script.
-const ENV_OPENVINO_LIB_PATH: &'static str = "OPENVINO_LIB_PATH";
+const ENV_OPENVINO_LIB_PATH: &str = "OPENVINO_LIB_PATH";
 
 fn main() {
     // Trigger rebuild on changes to build.rs and Cargo.toml and every source file.

--- a/crates/openvino-sys/src/lib.rs
+++ b/crates/openvino-sys/src/lib.rs
@@ -15,10 +15,14 @@
 //! let version = unsafe { CStr::from_ptr(openvino_sys::ie_c_api_version().api_version) };
 //! assert!(version.to_string_lossy().starts_with("2"));
 //! ```
-#![allow(non_upper_case_globals)]
-#![allow(non_camel_case_types)]
-#![allow(non_snake_case)]
-#![allow(dead_code)]
+
+#![allow(non_snake_case, non_camel_case_types, non_upper_case_globals)]
+#![allow(unused, dead_code)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(clippy::must_use_candidate)]
+#![allow(clippy::wildcard_imports)]
 
 mod linking;
 

--- a/crates/openvino-sys/src/linking/dynamic.rs
+++ b/crates/openvino-sys/src/linking/dynamic.rs
@@ -12,6 +12,10 @@ macro_rules! link {
     ) => (
         /// When compiled as a dynamically-linked library, this function does nothing. It exists to
         /// provide a consistent API with the runtime-linked version.
+        ///
+        /// # Errors
+        ///
+        /// This version never fails.
         pub fn load() -> Result<(), String> {
             Ok(())
         }

--- a/crates/openvino-sys/src/linking/runtime.rs
+++ b/crates/openvino-sys/src/linking/runtime.rs
@@ -43,10 +43,7 @@ macro_rules! link {
         where
             F: FnOnce(&SharedLibrary) -> T,
         {
-            match LIBRARY.read().unwrap().as_ref() {
-                Some(library) => Some(f(&library)),
-                _ => None,
-            }
+            LIBRARY.read().unwrap().as_ref().map(|library| f(&library))
         }
 
         // The set of functions loaded dynamically.
@@ -74,6 +71,10 @@ macro_rules! link {
         }
 
         /// Load all of the function definitions from a shared library.
+        ///
+        /// # Errors
+        ///
+        /// May fail if the `openvino-finder` cannot discover the library on the current system.
         pub fn load() -> Result<(), String> {
             match crate::library::find() {
                 None => Err("Unable to find the `inference_engine_c_api` library to load".into()),

--- a/crates/openvino-tensor-converter/src/lib.rs
+++ b/crates/openvino-tensor-converter/src/lib.rs
@@ -1,3 +1,13 @@
+//! An experimental library demonstrating how to use OpenCV in Rust to convert images into
+//! OpenVINO-compatible tensors.
+//!
+//! > WARNING: this is still experimental--no correctness guarantees!
+
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+
 use core::{fmt, slice};
 use log::info;
 use opencv;
@@ -67,6 +77,7 @@ pub fn convert<P: AsRef<Path>>(
     Ok(dst_slice.to_vec())
 }
 
+/// Container for the reasons a conversion can fail.
 #[derive(Debug)]
 pub struct ConversionError(String);
 impl fmt::Display for ConversionError {
@@ -85,6 +96,7 @@ impl From<ParseIntError> for ConversionError {
     }
 }
 
+/// Define the dimensions and pixel precision of an image.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Dimensions {
     height: i32,
@@ -140,9 +152,12 @@ impl FromStr for Dimensions {
     }
 }
 
+/// Distinguish the precision of each pixel.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Precision {
+    /// Each pixel is an 8-bit value.
     U8,
+    /// Each pixel is a 32-bit floating point value.
     FP32,
 }
 impl Precision {

--- a/crates/openvino/Cargo.toml
+++ b/crates/openvino/Cargo.toml
@@ -7,6 +7,8 @@ readme = "README.md"
 authors = ["OpenVINO Project Developers"]
 repository = "https://github.com/intel/openvino-rs"
 documentation = "https://docs.rs/openvino"
+keywords = ["openvino", "machine-learning", "ml", "neural-network"]
+categories = ["api-bindings", "science"]
 edition = "2018"
 exclude = [
     "/tests"

--- a/crates/openvino/src/error.rs
+++ b/crates/openvino/src/error.rs
@@ -1,8 +1,9 @@
 use thiserror::Error;
 
 /// Enumerate errors returned by the OpenVINO implementation. See
-/// [IEStatusCode](https://docs.openvinotoolkit.org/latest/ie_c_api/ie__c__api_8h.html#a391683b1e8e26df8b58d7033edd9ee83).
-/// TODO This could be auto-generated (https://github.com/intel/openvino-rs/issues/20).
+/// [`IEStatusCode`](https://docs.openvinotoolkit.org/latest/ie_c_api/ie__c__api_8h.html#a391683b1e8e26df8b58d7033edd9ee83).
+// TODO This could be auto-generated (https://github.com/intel/openvino-rs/issues/20).
+#[allow(missing_docs)]
 #[derive(Debug, Error, PartialEq)]
 pub enum InferenceError {
     #[error("general error")]
@@ -34,7 +35,11 @@ pub enum InferenceError {
 }
 
 impl InferenceError {
+    /// Convert an `error_code` to a [`Result`]:
+    /// - `0` becomes `Ok`
+    /// - anything else becomes `Err` containing an [`InferenceError`]
     pub fn from(error_code: i32) -> Result<(), InferenceError> {
+        #[allow(clippy::enum_glob_use)]
         use InferenceError::*;
         match error_code {
             openvino_sys::IEStatusCode_OK => Ok(()),
@@ -56,8 +61,9 @@ impl InferenceError {
 }
 
 /// Enumerate setup failures: in some cases, this library will call library-loading code that may
-/// fail in a different way (i.e., [LoadingError]) than the calls to the OpenVINO libraries (i.e.,
-/// [InferenceError]).
+/// fail in a different way (i.e., [`LoadingError`]) than the calls to the OpenVINO libraries (i.e.,
+/// [`InferenceError`]).
+#[allow(missing_docs)]
 #[derive(Debug, Error)]
 pub enum SetupError {
     #[error("inference error")]
@@ -67,6 +73,7 @@ pub enum SetupError {
 }
 
 /// Enumerate the ways that library loading can fail.
+#[allow(missing_docs)]
 #[derive(Debug, Error)]
 pub enum LoadingError {
     #[error("system failed to load shared libraries (see https://github.com/intel/openvino-rs/blob/main/crates/openvino-finder): {0}")]

--- a/crates/openvino/src/lib.rs
+++ b/crates/openvino/src/lib.rs
@@ -14,6 +14,17 @@
 //! let _ = openvino::Core::new(None).expect("to instantiate the OpenVINO library");
 //! ```
 
+#![deny(missing_docs)]
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(
+    clippy::must_use_candidate,
+    clippy::module_name_repetitions,
+    clippy::missing_errors_doc,
+    clippy::len_without_is_empty
+)]
+
 mod blob;
 mod core;
 mod error;

--- a/crates/openvino/src/network.rs
+++ b/crates/openvino/src/network.rs
@@ -1,6 +1,6 @@
 //! Contains the network representations in OpenVINO:
-//!  - [CNNNetwork] is the OpenVINO representation of a neural network
-//!  - [ExecutableNetwork] is the compiled representation of a [CNNNetwork] for a device.
+//!  - [`CNNNetwork`] is the OpenVINO representation of a neural network
+//!  - [`ExecutableNetwork`] is the compiled representation of a [`CNNNetwork`] for a device.
 
 use crate::request::InferRequest;
 use crate::{cstr, drop_using_function, try_unsafe, util::Result};
@@ -15,7 +15,7 @@ use openvino_sys::{
 use std::ffi::CStr;
 
 /// See
-/// [CNNNetwork](https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1CNNNetwork.html).
+/// [`CNNNetwork`](https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1CNNNetwork.html).
 pub struct CNNNetwork {
     pub(crate) instance: *mut ie_network_t,
 }
@@ -38,34 +38,34 @@ impl CNNNetwork {
 
     /// Retrieve the name identifying the input tensor at `index`.
     pub fn get_input_name(&self, index: usize) -> Result<String> {
-        let mut cname = std::ptr::null_mut();
+        let mut c_name = std::ptr::null_mut();
         try_unsafe!(ie_network_get_input_name(
             self.instance,
             index,
-            &mut cname as *mut *mut _
+            &mut c_name as *mut *mut _
         ))?;
-        let name = unsafe { CStr::from_ptr(cname) }
+        let rust_name = unsafe { CStr::from_ptr(c_name) }
             .to_string_lossy()
             .into_owned();
-        unsafe { ie_network_name_free(&mut cname as *mut *mut _) };
-        debug_assert!(cname.is_null());
-        Ok(name)
+        unsafe { ie_network_name_free(&mut c_name as *mut *mut _) };
+        debug_assert!(c_name.is_null());
+        Ok(rust_name)
     }
 
     /// Retrieve the name identifying the output tensor at `index`.
     pub fn get_output_name(&self, index: usize) -> Result<String> {
-        let mut cname = std::ptr::null_mut();
+        let mut c_name = std::ptr::null_mut();
         try_unsafe!(ie_network_get_output_name(
             self.instance,
             index,
-            &mut cname as *mut *mut _
+            &mut c_name as *mut *mut _
         ))?;
-        let name = unsafe { CStr::from_ptr(cname) }
+        let rust_name = unsafe { CStr::from_ptr(c_name) }
             .to_string_lossy()
             .into_owned();
-        unsafe { ie_network_name_free(&mut cname as *mut *mut _) };
-        debug_assert!(cname.is_null());
-        Ok(name)
+        unsafe { ie_network_name_free(&mut c_name as *mut *mut _) };
+        debug_assert!(c_name.is_null());
+        Ok(rust_name)
     }
 
     /// Configure a resize algorithm for the input tensor at `input_name`.
@@ -110,14 +110,14 @@ impl CNNNetwork {
 }
 
 /// See
-/// [ExecutableNetwork](https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1ExecutableNetwork.html).
+/// [`ExecutableNetwork`](https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1ExecutableNetwork.html).
 pub struct ExecutableNetwork {
     pub(crate) instance: *mut ie_executable_network_t,
 }
 drop_using_function!(ExecutableNetwork, ie_exec_network_free);
 
 impl ExecutableNetwork {
-    /// Create an [InferRequest].
+    /// Create an [`InferRequest`].
     pub fn create_infer_request(&mut self) -> Result<InferRequest> {
         let mut instance = std::ptr::null_mut();
         try_unsafe!(ie_exec_network_create_infer_request(

--- a/crates/openvino/src/request.rs
+++ b/crates/openvino/src/request.rs
@@ -5,7 +5,8 @@ use openvino_sys::{
     ie_infer_request_set_batch, ie_infer_request_set_blob, ie_infer_request_t,
 };
 
-/// See [InferRequest](https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1InferRequest.html).
+/// See
+/// [`InferRequest`](https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1InferRequest.html).
 pub struct InferRequest {
     pub(crate) instance: *mut ie_infer_request_t,
 }
@@ -18,7 +19,7 @@ impl InferRequest {
     }
 
     /// Assign a [Blob] to the input (i.e. `name`) on the network.
-    pub fn set_blob(&mut self, name: &str, blob: Blob) -> Result<()> {
+    pub fn set_blob(&mut self, name: &str, blob: &Blob) -> Result<()> {
         try_unsafe!(ie_infer_request_set_blob(
             self.instance,
             cstr!(name),

--- a/crates/openvino/src/tensor_desc.rs
+++ b/crates/openvino/src/tensor_desc.rs
@@ -1,13 +1,18 @@
 use crate::{Layout, Precision};
 use openvino_sys::{dimensions_t, tensor_desc_t};
 
-/// See [TensorDesc](https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1TensorDesc.html).
+/// See
+/// [`TensorDesc`](https://docs.openvinotoolkit.org/latest/classInferenceEngine_1_1TensorDesc.html).
 pub struct TensorDesc {
     pub(crate) instance: tensor_desc_t,
 }
 
 impl TensorDesc {
-    /// Construct a new [TensorDesc] from its C API components.
+    /// Construct a new [`TensorDesc`] from its C API components.
+    ///
+    /// # Panics
+    ///
+    /// Only (currently) handles up to eight dimensions; will panic if exceeded.
     pub fn new(layout: Layout, dimensions: &[usize], precision: Precision) -> Self {
         // Setup dimensions.
         assert!(dimensions.len() < 8);
@@ -27,7 +32,7 @@ impl TensorDesc {
         }
     }
 
-    /// Get the number of elements described by this [TensorDesc].
+    /// Get the number of elements described by this [`TensorDesc`].
     pub fn len(&self) -> usize {
         self.instance.dims.dims[..self.instance.dims.ranks as usize]
             .iter()

--- a/crates/openvino/src/util.rs
+++ b/crates/openvino/src/util.rs
@@ -14,7 +14,7 @@ macro_rules! cstr {
     };
 }
 
-/// Convert an unsafe call to openvino-sys into an [InferenceError].
+/// Convert an unsafe call to openvino-sys into an [`InferenceError`].
 #[macro_export]
 macro_rules! try_unsafe {
     ($e: expr) => {

--- a/crates/openvino/tests/classify-alexnet.rs
+++ b/crates/openvino/tests/classify-alexnet.rs
@@ -31,10 +31,10 @@ fn classify_alexnet() {
     // Read the image.
     let tensor_data = fs::read(Fixture::tensor()).unwrap();
     let tensor_desc = TensorDesc::new(Layout::NHWC, &[1, 3, 227, 227], Precision::FP32);
-    let blob = Blob::new(tensor_desc, &tensor_data).unwrap();
+    let blob = Blob::new(&tensor_desc, &tensor_data).unwrap();
 
     // Execute inference.
-    infer_request.set_blob(input_name, blob).unwrap();
+    infer_request.set_blob(input_name, &blob).unwrap();
     infer_request.infer().unwrap();
     let mut results = infer_request.get_blob(output_name).unwrap();
     let buffer = unsafe { results.buffer_mut_as_type::<f32>().unwrap().to_vec() };

--- a/crates/openvino/tests/classify-inception.rs
+++ b/crates/openvino/tests/classify-inception.rs
@@ -31,10 +31,10 @@ fn classify_inception() {
     // Read the image.
     let tensor_data = fs::read(Fixture::tensor()).unwrap();
     let tensor_desc = TensorDesc::new(Layout::NHWC, &[1, 3, 299, 299], Precision::FP32);
-    let blob = Blob::new(tensor_desc, &tensor_data).unwrap();
+    let blob = Blob::new(&tensor_desc, &tensor_data).unwrap();
 
     // Execute inference.
-    infer_request.set_blob(input_name, blob).unwrap();
+    infer_request.set_blob(input_name, &blob).unwrap();
     infer_request.infer().unwrap();
     let mut results = infer_request.get_blob(output_name).unwrap();
     let buffer = unsafe { results.buffer_mut_as_type::<f32>().unwrap().to_vec() };

--- a/crates/openvino/tests/classify-mobilenet.rs
+++ b/crates/openvino/tests/classify-mobilenet.rs
@@ -32,10 +32,10 @@ fn classify_mobilenet() {
     // Read the image.
     let tensor_data = fs::read(Fixture::tensor()).unwrap();
     let tensor_desc = TensorDesc::new(Layout::NHWC, &[1, 3, 224, 224], Precision::FP32);
-    let blob = Blob::new(tensor_desc, &tensor_data).unwrap();
+    let blob = Blob::new(&tensor_desc, &tensor_data).unwrap();
 
     // Execute inference.
-    infer_request.set_blob(input_name, blob).unwrap();
+    infer_request.set_blob(input_name, &blob).unwrap();
     infer_request.infer().unwrap();
     let mut results = infer_request.get_blob(output_name).unwrap();
     let buffer = unsafe { results.buffer_mut_as_type::<f32>().unwrap().to_vec() };

--- a/crates/openvino/tests/detect-inception.rs
+++ b/crates/openvino/tests/detect-inception.rs
@@ -40,10 +40,10 @@ fn detect_inception() {
     // Read the image.
     let tensor_data = fs::read(Fixture::tensor()).unwrap();
     let tensor_desc = TensorDesc::new(Layout::NHWC, &[1, 3, 481, 640], Precision::U8);
-    let blob = Blob::new(tensor_desc, &tensor_data).unwrap();
+    let blob = Blob::new(&tensor_desc, &tensor_data).unwrap();
 
     // Execute inference.
-    infer_request.set_blob(input_name, blob).unwrap();
+    infer_request.set_blob(input_name, &blob).unwrap();
     infer_request.infer().unwrap();
     let mut results = infer_request.get_blob(output_name).unwrap();
     let buffer = unsafe { results.buffer_mut_as_type::<f32>().unwrap().to_vec() };

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -2,6 +2,7 @@
 name = "xtask"
 description = "Utility scripts for the openvino-rs workspace."
 version = "0.1.0"
+license = "Apache-2.0"
 authors = ["OpenVINO Project Developers"]
 edition = "2018"
 publish = false

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -48,7 +48,7 @@ impl BumpCommand {
 
         // Update the Cargo.toml files.
         let next_version_str = &next_version.to_string();
-        for c in publishable_crates.iter() {
+        for c in &publishable_crates {
             update_version(c, &publishable_crates, next_version_str, self.dry_run)?;
         }
 
@@ -68,7 +68,7 @@ impl BumpCommand {
                     .arg("-m")
                     .arg(&commit_message)
                     .status()
-                    .with_context(|| format!("failed to run `git commit` command"))?
+                    .with_context(|| "failed to run `git commit` command".to_string())?
                     .success());
             }
         }
@@ -99,8 +99,9 @@ impl std::str::FromStr for Bump {
 }
 
 /// Update the version of `krate` and any dependencies in `crates` to match the version passed in
-/// `next_version`. Adapted from
-/// https://github.com/bytecodealliance/wasmtime/blob/main/scripts/publish.rs
+/// `next_version`. Adapted from Wasmtime's [publish.rs] script.
+///
+/// [publish.rs]: https://github.com/bytecodealliance/wasmtime/blob/main/scripts/publish.rs
 fn update_version(
     krate: &Crate,
     crates: &[Crate],
@@ -124,7 +125,7 @@ fn update_version(
         }
 
         // Check whether we have reached the `[dependencies]` section.
-        reading_dependencies = if line.starts_with("[") {
+        reading_dependencies = if line.starts_with('[') {
             line.contains("dependencies")
         } else {
             reading_dependencies
@@ -158,7 +159,7 @@ fn update_version(
             new_contents.push_str(line);
         }
 
-        new_contents.push_str("\n");
+        new_contents.push('\n');
     }
 
     if !dry_run {

--- a/crates/xtask/src/codegen.rs
+++ b/crates/xtask/src/codegen.rs
@@ -1,6 +1,5 @@
 use crate::util::path_to_crates;
 use anyhow::{anyhow, ensure, Context, Result};
-use bindgen;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -30,7 +29,7 @@ impl CodegenCommand {
         let output_directory = self.path_to_output_directory()?;
 
         // Generate the type bindings into `.../types.rs`.
-        let type_bindings = self.generate_type_bindings(&header_file)?;
+        let type_bindings = Self::generate_type_bindings(&header_file)?;
         let type_bindings_path = output_directory.join(TYPES_FILE);
         type_bindings
             .write_to_file(&type_bindings_path)
@@ -39,7 +38,7 @@ impl CodegenCommand {
             })?;
 
         // Generate the function bindings into `.../functions.rs`, with a prefix and suffix.
-        let function_bindings = self.generate_function_bindings(&header_file)?;
+        let function_bindings = Self::generate_function_bindings(&header_file)?;
         let function_bindings_path = output_directory.join(FUNCTIONS_FILE);
         {
             let mut function_bindings_file = Box::new(File::create(&function_bindings_path)?);
@@ -98,7 +97,7 @@ impl CodegenCommand {
         })
     }
 
-    fn generate_type_bindings<P: AsRef<Path>>(&self, header_file: P) -> Result<bindgen::Bindings> {
+    fn generate_type_bindings<P: AsRef<Path>>(header_file: P) -> Result<bindgen::Bindings> {
         bindgen::Builder::default()
             .header(header_file.as_ref().to_string_lossy())
             .allowlist_type("ie_.*")
@@ -131,10 +130,7 @@ impl CodegenCommand {
             .map_err(|_| anyhow!("unable to generate type bindings"))
     }
 
-    fn generate_function_bindings<P: AsRef<Path>>(
-        &self,
-        header_file: P,
-    ) -> Result<bindgen::Bindings> {
+    fn generate_function_bindings<P: AsRef<Path>>(header_file: P) -> Result<bindgen::Bindings> {
         bindgen::Builder::default()
             .header(header_file.as_ref().to_string_lossy())
             .allowlist_function("ie_.*")
@@ -158,8 +154,8 @@ impl CodegenCommand {
     }
 }
 
-const TYPES_FILE: &'static str = "types.rs";
-const FUNCTIONS_FILE: &'static str = "functions.rs";
-const DEFAULT_OUTPUT_DIRECTORY: &'static str = "openvino-sys/src/generated";
-const DEFAULT_HEADER_FILE: &'static str =
+const TYPES_FILE: &str = "types.rs";
+const FUNCTIONS_FILE: &str = "functions.rs";
+const DEFAULT_OUTPUT_DIRECTORY: &str = "openvino-sys/src/generated";
+const DEFAULT_HEADER_FILE: &str =
     "openvino-sys/upstream/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h";

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,3 +1,8 @@
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+#![warn(clippy::cargo)]
+#![allow(clippy::module_name_repetitions)]
+
 mod bump;
 mod codegen;
 mod publish;

--- a/crates/xtask/src/publish.rs
+++ b/crates/xtask/src/publish.rs
@@ -43,12 +43,12 @@ impl PublishCommand {
         for krate in PUBLICATION_ORDER {
             println!("> publish {}", krate);
             if !self.dry_run {
-                let crate_dir = crates_dir.clone().join(krate);
+                let krate_dir = crates_dir.clone().join(krate);
                 let exec_result = exec(
                     Command::new("cargo")
                         .arg("publish")
                         .arg("--no-verify")
-                        .current_dir(&crate_dir),
+                        .current_dir(&krate_dir),
                 );
 
                 // We want to continue even if a crate does not publish: this allows us to re-run

--- a/crates/xtask/src/util.rs
+++ b/crates/xtask/src/util.rs
@@ -14,15 +14,15 @@ pub fn exec(command: &mut Command) -> Result<()> {
     }
 }
 
-/// Determine the path to the `crates` directory`.
+/// Determine the path to the `crates` directory.
 pub fn path_to_crates() -> Result<PathBuf> {
     Ok(PathBuf::from(file!())
         .parent()
-        .with_context(|| format!("Failed to get parent of path."))?
+        .with_context(|| "Failed to get parent of path.".to_string())?
         .parent()
-        .with_context(|| format!("Failed to get parent of path."))?
+        .with_context(|| "Failed to get parent of path.".to_string())?
         .parent()
-        .with_context(|| format!("Failed to get parent of path."))?
+        .with_context(|| "Failed to get parent of path.".to_string())?
         .into())
 }
 
@@ -57,10 +57,10 @@ pub fn get_crates() -> Result<Vec<Crate>> {
 
         crates.push(Crate {
             name,
+            path,
             version,
             publish,
-            path,
-        })
+        });
     }
 
     Ok(crates)

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,23 @@
+# Documentation for this configuration file can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/cfg.html
+
+# See https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html.
+[licenses]
+allow = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "ISC",
+    "MIT",
+]
+
+# See https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html.
+[bans]
+multiple-versions = "deny"
+wildcards = "allow"
+
+# Skip some multiple-versions checks until they can be fixed.
+skip-tree = [
+    # `pretty_env_logger` depends on an old version of `env_logger` that has a version mismatch with
+    # the `env_logger` depended upon by `bindgen`.
+    { name = "pretty_env_logger", depth = 5 },
+]


### PR DESCRIPTION
This change adds several static analyses to the project and configures them to run in CI for each pull request. Due to the recommendations for these scans, slight changes were made to several APIs (i.e., pass by reference instead of the owned object) and a small upgrade to a dependent crate. This will require a bump to v0.4.0.