### PR TITLE
Upgrade to use upstream OpenVINO 2022.1 release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -61,10 +61,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu18, ubuntu20]
-        version: [2020.4, 2021.1, 2021.2, 2021.3, 2021.4]
-        exclude:
-        - os: ubuntu20
-          version: 2020.4
+        version: [2022.1.0]
     steps:
     - uses: actions/checkout@v2
       with:
@@ -79,7 +76,7 @@ jobs:
   # binaries, then compile against these).
   runtime_binaries:
     name: From runtime-linked binaries
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
@@ -87,10 +84,10 @@ jobs:
         lfs: true
     - name: Checkout LFS obects
       run: git lfs checkout
-    - uses: abrown/install-openvino-action@v1
+    - uses: abrown/install-openvino-action@v3
     - name: Build and run tests
       run: |
-        source /opt/intel/openvino/bin/setupvars.sh
+        source /opt/intel/openvino_2022/setupvars.sh
         cargo test --features openvino-sys/runtime-linking
 
   # Build and test from an existing OpenVINO installation inside a Docker image (i.e. download the

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,8 +49,9 @@ jobs:
     - name: Run tests
       # For some reason the library path is not set during the doc tests (`--doc`, see
       # https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection) so we skip them
-      # here: issue at https://github.com/intel/openvino-rs/issues/25.
-      run: cargo test --verbose --features openvino-sys/from-source --lib --tests
+      # here: issue at https://github.com/intel/openvino-rs/issues/25. Also, the `from-source` build
+      # does not know how to run the inception SSD test.
+      run: cargo test --verbose --features openvino-sys/from-source --lib --tests -- --skip detect_inception
 
   # Build and test from an existing OpenVINO installation inside a Docker image (i.e. download the
   # binaries, then compile against these).

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN OPENVINO_INSTALL_DIR=/opt/intel/openvino cargo build -vv
 
 # Test; note that we need to setup the library paths before using them since the
 # OPENVINO_INSTALL_DIR can only affect the build library search path.
-RUN ["/bin/bash", "-c", "source /opt/intel/openvino/bin/setupvars.sh && OPENVINO_INSTALL_DIR=/opt/intel/openvino cargo test -v"]
+RUN ["/bin/bash", "-c", "source /opt/intel/openvino/setupvars.sh && OPENVINO_INSTALL_DIR=/opt/intel/openvino cargo test -v"]

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ git lfs checkout
 
 ```shell script
 cargo build
-source /opt/intel/openvino/bin/setupvars.sh
+source /opt/intel/openvino/setupvars.sh
 cargo test
 ```
 
@@ -55,7 +55,7 @@ script will do this automatically.
 
 ```shell script
 cargo build --features openvino-sys/runtime-linking
-source /opt/intel/openvino/bin/setupvars.sh
+source /opt/intel/openvino/setupvars.sh
 cargo test --features openvino-sys/runtime-linking
 ```
 
@@ -64,7 +64,7 @@ The `openvino-rs` crates also support linking from a shared library at runtime (
 present and only later--at runtime--providing the OpenVINO™ shared libraries. All underlying system
 calls are wrapped so that a call to `openvino_sys::library::load` will link them to their shared
 library implementation (using the logic in [openvino-finder] to locate the shared libraries). For
-high-level users, call `openvino::Core::new` first to automatically load and link the libraries. 
+high-level users, call `openvino::Core::new` first to automatically load and link the libraries.
 
 
 

--- a/crates/openvino-finder/src/lib.rs
+++ b/crates/openvino-finder/src/lib.rs
@@ -126,7 +126,7 @@ const KNOWN_INSTALLATION_SUBDIRECTORIES: &[&str] =
 const KNOWN_BUILD_SUBDIRECTORIES: &[&str] = &[
     "bin/intel64/Debug/lib",
     "bin/intel64/Release/lib",
-    "inference-engine/temp/tbb/lib",
+    "temp/tbb/lib",
 ];
 
 #[cfg(test)]

--- a/crates/openvino-finder/src/lib.rs
+++ b/crates/openvino-finder/src/lib.rs
@@ -36,7 +36,7 @@ pub fn find(library_name: &str) -> Option<PathBuf> {
     }
 
     // Search using the `OPENVINO_INSTALL_DIR` environment variable; this may be set by users of the
-    // openvino-rs library.
+    // `openvino-rs` library.
     if let Some(install_dir) = env::var_os(ENV_OPENVINO_INSTALL_DIR) {
         let install_dir = PathBuf::from(install_dir);
         for lib_dir in KNOWN_INSTALLATION_SUBDIRECTORIES {
@@ -46,7 +46,7 @@ pub fn find(library_name: &str) -> Option<PathBuf> {
     }
 
     // Search using the `OPENVINO_BUILD_DIR` environment variable; this may be set by users of the
-    // openvino-rs library.
+    // `openvino-rs` library.
     if let Some(build_dir) = env::var_os(ENV_OPENVINO_BUILD_DIR) {
         let install_dir = PathBuf::from(build_dir);
         for lib_dir in KNOWN_BUILD_SUBDIRECTORIES {
@@ -56,7 +56,7 @@ pub fn find(library_name: &str) -> Option<PathBuf> {
     }
 
     // Search using the `INTEL_OPENVINO_DIR` environment variable; this is set up by an OpenVINO
-    // installation (e.g. `source /opt/intel/openvino/bin/setupvars.sh`).
+    // installation (e.g. `source /opt/intel/openvino/setupvars.sh`).
     if let Some(install_dir) = env::var_os(ENV_INTEL_OPENVINO_DIR) {
         let install_dir = PathBuf::from(install_dir);
         for lib_dir in KNOWN_INSTALLATION_SUBDIRECTORIES {
@@ -66,8 +66,7 @@ pub fn find(library_name: &str) -> Option<PathBuf> {
     }
 
     // Search in the OS library path (i.e. `LD_LIBRARY_PATH` on Linux, `PATH` on Windows, and
-    // `DYLD_LIBRARY_PATH` on MacOS). See
-    // https://docs.openvinotoolkit.org/latest/openvino_docs_IE_DG_Deep_Learning_Inference_Engine_DevGuide.html
+    // `DYLD_LIBRARY_PATH` on MacOS).
     if let Some(path) = env::var_os(ENV_LIBRARY_PATH) {
         for lib_dir in env::split_paths(&path) {
             let search_path = lib_dir.join(&file);
@@ -110,24 +109,19 @@ cfg_if! {
 cfg_if! {
     if #[cfg(any(target_os = "linux", target_os = "macos"))] {
         const DEFAULT_INSTALLATION_DIRECTORIES: & [& str] =
-            &["/opt/intel/openvino_2021", "/opt/intel/openvino"];
+            &["/opt/intel/openvino_2022", "/opt/intel/openvino"];
     } else if #[cfg(target_os = "windows")] {
         const DEFAULT_INSTALLATION_DIRECTORIES: & [& str] = &[
+            "C:\\Program Files (x86)\\Intel\\openvino_2022",
             "C:\\Program Files (x86)\\Intel\\openvino",
-            "C:\\Program Files (x86)\\Intel\\openvino_2021",
         ];
     } else {
         const DEFAULT_INSTALLATION_DIRECTORIES: & [& str] = &[];
     }
 }
 
-const KNOWN_INSTALLATION_SUBDIRECTORIES: &[&str] = &[
-    "deployment_tools/ngraph/lib",
-    "deployment_tools/inference_engine/lib/intel64",
-    "deployment_tools/inference_engine/external/hddl/lib",
-    "deployment_tools/inference_engine/external/gna/lib",
-    "deployment_tools/inference_engine/external/tbb/lib",
-];
+const KNOWN_INSTALLATION_SUBDIRECTORIES: &[&str] =
+    &["runtime/lib/intel64", "runtime/3rdparty/tbb/lib"];
 
 const KNOWN_BUILD_SUBDIRECTORIES: &[&str] = &[
     "bin/intel64/Debug/lib",
@@ -139,11 +133,11 @@ const KNOWN_BUILD_SUBDIRECTORIES: &[&str] = &[
 mod test {
     use super::*;
 
-    /// This test uses `find` to search for the `inference_engine_c_api` library on the local
+    /// This test uses `find` to search for the `openvino_c` library on the local
     /// system.
     #[test]
-    fn find_inference_engine_c_api_locally() {
+    fn find_openvino_c_locally() {
         pretty_env_logger::init();
-        assert!(find("inference_engine_c_api").is_some());
+        assert!(find("openvino_c").is_some());
     }
 }

--- a/crates/openvino-sys/Cargo.toml
+++ b/crates/openvino-sys/Cargo.toml
@@ -15,11 +15,12 @@ include = [
     "/README.md",
     "/build.rs",
     "/src",
-    # Since it is quite difficult to fit OpenVINO into the 10MB crate limit, this crate is published with only the
-    # sources necessary for bindgen to build the Rust bindings. This means that the crate can only be either:
+    # Since it is quite difficult to fit OpenVINO into the 10MB crate limit, this crate is published
+    # with only the sources necessary for bindgen to build the Rust bindings. This means that the
+    # crate can only be either:
     # - built from OpenVINO sources when built as the primary crate (unlikely usage)
     # - built from an OpenVINO installation when used as a dependency
-    "/upstream/inference-engine/ie_bridges/c/include",
+    "/upstream/src/bindings/c/include",
 ]
 links = "inference_engine_c_api"
 
@@ -36,13 +37,15 @@ openvino-finder = {version = "0.3.3", path = "../openvino-finder" }
 default = ["cpu"]
 
 # Plugin features: if building from source, this allows selecting which OpenVINO plugins to build.
-all = ["cpu", "gpu", "gna", "hetero", "multi", "myriad"]
+all = ["auto", "auto_batch", "cpu", "gpu", "gna", "hetero", "myriad", "multi"]
+auto = []
+auto_batch = []
 cpu = []
 gpu = []
 gna = []
 hetero = []
-multi = []
 myriad = []
+multi = []
 
 # Linking features: `build.rs` will default to dynamic linking if none is selected.
 dynamic-linking = [] # Will find and bind to an OpenVINO shared library at compile time.

--- a/crates/openvino-sys/src/generated/functions.rs
+++ b/crates/openvino-sys/src/generated/functions.rs
@@ -16,7 +16,7 @@ extern "C" {
 }
 extern "C" {
     #[doc = " @brief Release the memory allocated by ie_param_t."]
-    #[doc = " @param version A pointer to the ie_param_t to free memory."]
+    #[doc = " @param param A pointer to the ie_param_t to free memory."]
     pub fn ie_param_free(param: *mut ie_param_t);
 }
 extern "C" {
@@ -42,7 +42,7 @@ extern "C" {
     #[doc = " @brief Gets version information of the device specified. Use the ie_core_versions_free() method to free memory."]
     #[doc = " @ingroup Core"]
     #[doc = " @param core A pointer to ie_core_t instance."]
-    #[doc = " @param device_name Name to indentify device."]
+    #[doc = " @param device_name Name to identify device."]
     #[doc = " @param versions A pointer to versions corresponding to device_name."]
     #[doc = " @return Status code of the operation: OK(0) for success."]
     pub fn ie_core_get_versions(
@@ -60,7 +60,7 @@ extern "C" {
 extern "C" {
     #[doc = " @brief Reads the model from the .xml and .bin files of the IR. Use the ie_network_free() method to free memory."]
     #[doc = " @ingroup Core"]
-    #[doc = " @param core A pointer to ie_core_t instance."]
+    #[doc = " @param core A pointer to the ie_core_t instance."]
     #[doc = " @param xml .xml file's path of the IR."]
     #[doc = " @param weights_file .bin file's path of the IR, if path is empty, will try to read bin file with the same name as xml and"]
     #[doc = " if bin file with the same name was not found, will load IR without weights."]
@@ -76,7 +76,7 @@ extern "C" {
 extern "C" {
     #[doc = " @brief Reads the model from an xml string and a blob of the bin part of the IR. Use the ie_network_free() method to free memory."]
     #[doc = " @ingroup Core"]
-    #[doc = " @param core A pointer to ie_core_t instance."]
+    #[doc = " @param core A pointer to the ie_core_t instance."]
     #[doc = " @param xml_content Xml content of the IR."]
     #[doc = " @param xml_content_size Number of bytes in the xml content of the IR."]
     #[doc = " @param weight_blob Blob containing the bin part of the IR."]
@@ -91,12 +91,61 @@ extern "C" {
     ) -> IEStatusCode;
 }
 extern "C" {
-    #[doc = " @brief Creates an executable network from a network object. Users can create as many networks as they need and use"]
+    #[doc = " @brief Creates an executable network from a network previously exported to a file. Users can create as many networks as they need and use"]
     #[doc = " them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory."]
     #[doc = " @ingroup Core"]
-    #[doc = " @param core A pointer to ie_core_t instance."]
-    #[doc = " @param network A pointer to ie_network instance."]
-    #[doc = " @param device_name Name of device to load network to."]
+    #[doc = " @param core A pointer to the ie_core_t instance."]
+    #[doc = " @param file_name A path to the location of the exported file."]
+    #[doc = " @param device_name A name of the device to load the network to."]
+    #[doc = " @param config Device configuration."]
+    #[doc = " @param exe_network A pointer to the newly created executable network."]
+    #[doc = " @return Status code of the operation: OK(0) for success."]
+    pub fn ie_core_import_network(
+        core: *mut ie_core_t,
+        file_name: *const ::std::os::raw::c_char,
+        device_name: *const ::std::os::raw::c_char,
+        config: *const ie_config_t,
+        exe_network: *mut *mut ie_executable_network_t,
+    ) -> IEStatusCode;
+}
+extern "C" {
+    #[doc = " @brief Creates an executable network from a network previously exported to memory. Users can create as many networks as they need and use"]
+    #[doc = " them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory."]
+    #[doc = " @ingroup Core"]
+    #[doc = " @param core A pointer to the ie_core_t instance."]
+    #[doc = " @param content A pointer to content of the exported network."]
+    #[doc = " @param content_size Number of bytes in the exported network."]
+    #[doc = " @param device_name A name of the device to load the network to."]
+    #[doc = " @param config Device configuration."]
+    #[doc = " @param exe_network A pointer to the newly created executable network."]
+    #[doc = " @return Status code of the operation: OK(0) for success."]
+    pub fn ie_core_import_network_from_memory(
+        core: *mut ie_core_t,
+        content: *const u8,
+        content_size: usize,
+        device_name: *const ::std::os::raw::c_char,
+        config: *const ie_config_t,
+        exe_network: *mut *mut ie_executable_network_t,
+    ) -> IEStatusCode;
+}
+extern "C" {
+    #[doc = " @brief Exports an executable network to a .bin file."]
+    #[doc = " @ingroup Core"]
+    #[doc = " @param exe_network A pointer to the newly created executable network."]
+    #[doc = " @param file_name Path to the file to export the network to."]
+    #[doc = " @return Status code of the operation: OK(0) for success."]
+    pub fn ie_core_export_network(
+        exe_network: *mut ie_executable_network_t,
+        file_name: *const ::std::os::raw::c_char,
+    ) -> IEStatusCode;
+}
+extern "C" {
+    #[doc = " @brief Creates an executable network from a given network object. Users can create as many networks as they need and use"]
+    #[doc = " them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory."]
+    #[doc = " @ingroup Core"]
+    #[doc = " @param core A pointer to the ie_core_t instance."]
+    #[doc = " @param network A pointer to the input ie_network instance to create the executable network from."]
+    #[doc = " @param device_name Name of the device to load the network to."]
     #[doc = " @param config Device configuration."]
     #[doc = " @param exe_network A pointer to the newly created executable network."]
     #[doc = " @return Status code of the operation: OK(0) for success."]
@@ -109,11 +158,29 @@ extern "C" {
     ) -> IEStatusCode;
 }
 extern "C" {
+    #[doc = " @brief Reads model and creates an executable network from IR or ONNX file. Users can create as many networks as they need and use"]
+    #[doc = " them simultaneously (up to the limitation of the hardware resources). Use the ie_exec_network_free() method to free memory."]
+    #[doc = " @ingroup Core"]
+    #[doc = " @param core A pointer to the ie_core_t instance."]
+    #[doc = " @param xml .xml file's path of the IR. Weights file name will be calculated automatically"]
+    #[doc = " @param device_name Name of device to load network to."]
+    #[doc = " @param config Device configuration."]
+    #[doc = " @param exe_network A pointer to the newly created executable network."]
+    #[doc = " @return Status code of the operation: OK(0) for success."]
+    pub fn ie_core_load_network_from_file(
+        core: *mut ie_core_t,
+        xml: *const ::std::os::raw::c_char,
+        device_name: *const ::std::os::raw::c_char,
+        config: *const ie_config_t,
+        exe_network: *mut *mut ie_executable_network_t,
+    ) -> IEStatusCode;
+}
+extern "C" {
     #[doc = " @brief Sets configuration for device."]
     #[doc = " @ingroup Core"]
     #[doc = " @param core A pointer to ie_core_t instance."]
     #[doc = " @param ie_core_config Device configuration."]
-    #[doc = " @param device_name An optinal name of a device. If device name is not specified,"]
+    #[doc = " @param device_name An optional name of a device. If device name is not specified,"]
     #[doc = " the config is set for all the registered devices."]
     #[doc = " @return Status code of the operation: OK(0) for success."]
     pub fn ie_core_set_config(
@@ -208,7 +275,7 @@ extern "C" {
     #[doc = " @brief Gets available devices for neural network inference."]
     #[doc = " @ingroup Core"]
     #[doc = " @param core A pointer to ie_core_t instance."]
-    #[doc = " @param avai_devices The devices are returned as { CPU, FPGA.0, FPGA.1, MYRIAD }"]
+    #[doc = " @param avai_devices The devices are returned as { CPU, GPU.0, GPU.1, MYRIAD }"]
     #[doc = " If there more than one device of specific type, they are enumerated with .# suffix"]
     #[doc = " @return Status code of the operation: OK(0) for success."]
     pub fn ie_core_get_available_devices(
@@ -256,7 +323,7 @@ extern "C" {
 }
 extern "C" {
     #[doc = " @brief Sets configuration for current executable network. Currently, the method can be used"]
-    #[doc = " when the network run on the Multi device and the configuration paramter is only can be \"MULTI_DEVICE_PRIORITIES\""]
+    #[doc = " when the network run on the Multi device and the configuration parameter is only can be \"MULTI_DEVICE_PRIORITIES\""]
     #[doc = " @ingroup ExecutableNetwork"]
     #[doc = " @param ie_exec_network A pointer to ie_executable_network_t instance."]
     #[doc = " @param param_config A pointer to device configuration.."]
@@ -272,7 +339,7 @@ extern "C" {
     #[doc = " @ingroup ExecutableNetwork"]
     #[doc = " @param ie_exec_network A pointer to ie_executable_network_t instance."]
     #[doc = " @param metric_config A configuration parameter name to request."]
-    #[doc = " @param param_result A configuration value corresponding to a configuration paramter name."]
+    #[doc = " @param param_result A configuration value corresponding to a configuration parameter name."]
     #[doc = " @return Status code of the operation: OK(0) for success."]
     pub fn ie_exec_network_get_config(
         ie_exec_network: *const ie_executable_network_t,
@@ -363,7 +430,7 @@ extern "C" {
     ) -> IEStatusCode;
 }
 extern "C" {
-    #[doc = " @brief When netowrk is loaded into the Infernece Engine, it is not required anymore and should be released"]
+    #[doc = " @brief When network is loaded into the Infernece Engine, it is not required anymore and should be released"]
     #[doc = " @ingroup Network"]
     #[doc = " @param network The pointer to the instance of the ie_network_t to free."]
     pub fn ie_network_free(network: *mut *mut ie_network_t);
@@ -371,6 +438,7 @@ extern "C" {
 extern "C" {
     #[doc = " @brief Get name of network."]
     #[doc = " @ingroup Network"]
+    #[doc = " @param network A pointer to the instance of the ie_network_t to get a name from."]
     #[doc = " @param name Name of the network."]
     #[doc = " @return Status code of the operation: OK(0) for success."]
     pub fn ie_network_get_name(
@@ -457,7 +525,7 @@ extern "C" {
     ) -> IEStatusCode;
 }
 extern "C" {
-    #[doc = " @Gets dimensions/shape of the input data with reversed order."]
+    #[doc = " @brief Gets dimensions/shape of the input data with reversed order."]
     #[doc = " @ingroup Network"]
     #[doc = " @param network A pointer to ie_network_t instance."]
     #[doc = " @param input_name Name of input data."]
@@ -474,7 +542,7 @@ extern "C" {
     #[doc = " @ingroup Network"]
     #[doc = " @param network A pointer to ie_network_t instance."]
     #[doc = " @param input_name Name of input data."]
-    #[doc = " @parm resize_alg_result The pointer to the resize algorithm used for input blob creation."]
+    #[doc = " @param resize_alg_result The pointer to the resize algorithm used for input blob creation."]
     #[doc = " @return Status code of the operation: OK(0) for success."]
     pub fn ie_network_get_input_resize_algorithm(
         network: *const ie_network_t,
@@ -501,7 +569,7 @@ extern "C" {
     #[doc = " @param network A pointer to ie_network_t instance."]
     #[doc = " @param input_name Name of input data."]
     #[doc = " @param colformat_result The pointer to the color format used for input blob creation."]
-    #[doc = " @reutrn Status code of the operation: OK(0) for success."]
+    #[doc = " @return Status code of the operation: OK(0) for success."]
     pub fn ie_network_get_color_format(
         network: *const ie_network_t,
         input_name: *const ::std::os::raw::c_char,
@@ -514,7 +582,7 @@ extern "C" {
     #[doc = " @param network A pointer to ie_network_t instance."]
     #[doc = " @param input_name Name of input data."]
     #[doc = " @param color_format Color format of the input data."]
-    #[doc = " @reutrn Status code of the operation: OK(0) for success."]
+    #[doc = " @return Status code of the operation: OK(0) for success."]
     pub fn ie_network_set_color_format(
         network: *mut ie_network_t,
         input_name: *const ::std::os::raw::c_char,
@@ -544,7 +612,7 @@ extern "C" {
 extern "C" {
     #[doc = " @brief Gets number of output for the network."]
     #[doc = " @ingroup Network"]
-    #[doc = " @param network A pointer to the instance of the ie_network_t to get number of ouput information."]
+    #[doc = " @param network A pointer to the instance of the ie_network_t to get number of output information."]
     #[doc = " @param size_result A number of the network's output information."]
     #[doc = " @return Status code of the operation: OK(0) for success."]
     pub fn ie_network_get_outputs_number(
@@ -789,7 +857,7 @@ extern "C" {
     ) -> IEStatusCode;
 }
 extern "C" {
-    #[doc = " @Releases the memory occupied by the ie_blob_t pointer."]
+    #[doc = " @brief Releases the memory occupied by the ie_blob_t pointer."]
     #[doc = " @ingroup Blob"]
     #[doc = " @param blob A pointer to the blob pointer to release memory."]
     pub fn ie_blob_free(blob: *mut *mut ie_blob_t);

--- a/crates/openvino-sys/src/generated/types.rs
+++ b/crates/openvino-sys/src/generated/types.rs
@@ -35,6 +35,7 @@ pub type ie_blob_t = ie_blob;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ie_version {
+    #[doc = "!< A string representing Inference Engine version"]
     pub api_version: *mut ::std::os::raw::c_char,
 }
 #[test]
@@ -68,10 +69,15 @@ pub type ie_version_t = ie_version;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ie_core_version {
+    #[doc = "!< A major version"]
     pub major: usize,
+    #[doc = "!< A minor version"]
     pub minor: usize,
+    #[doc = "!< A device name"]
     pub device_name: *const ::std::os::raw::c_char,
+    #[doc = "!< A build number"]
     pub build_number: *const ::std::os::raw::c_char,
+    #[doc = "!< A device description"]
     pub description: *const ::std::os::raw::c_char,
 }
 #[test]
@@ -145,7 +151,9 @@ pub type ie_core_version_t = ie_core_version;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ie_core_versions {
+    #[doc = "!< An array of device versions"]
     pub versions: *mut ie_core_version_t,
+    #[doc = "!< A number of versions in the array"]
     pub num_vers: usize,
 }
 #[test]
@@ -189,8 +197,11 @@ pub type ie_core_versions_t = ie_core_versions;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct ie_config {
+    #[doc = "!< A configuration key"]
     pub name: *const ::std::os::raw::c_char,
+    #[doc = "!< A configuration value"]
     pub value: *const ::std::os::raw::c_char,
+    #[doc = "!< A pointer to the next configuration value"]
     pub next: *mut ie_config,
 }
 #[test]
@@ -378,7 +389,9 @@ pub type ie_param_config_t = ie_param_config;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct dimensions {
+    #[doc = "!< A runk representing a number of dimensions"]
     pub ranks: usize,
+    #[doc = "!< An array of dimensions"]
     pub dims: [usize; 8usize],
 }
 #[test]
@@ -422,18 +435,31 @@ pub type dimensions_t = dimensions;
 #[doc = " @brief Layouts that the inference engine supports"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum layout_e {
+    #[doc = "!< \"ANY\" layout"]
     ANY = 0,
+    #[doc = "!< \"NCHW\" layout"]
     NCHW = 1,
+    #[doc = "!< \"NHWC\" layout"]
     NHWC = 2,
+    #[doc = "!< \"NCDHW\" layout"]
     NCDHW = 3,
+    #[doc = "!< \"NDHWC\" layout"]
     NDHWC = 4,
+    #[doc = "!< \"OIHW\" layout"]
     OIHW = 64,
+    #[doc = "!< \"SCALAR\" layout"]
     SCALAR = 95,
+    #[doc = "!< \"C\" layout"]
     C = 96,
+    #[doc = "!< \"CHW\" layout"]
     CHW = 128,
+    #[doc = "!< \"HW\" layout"]
     HW = 192,
+    #[doc = "!< \"NC\" layout"]
     NC = 193,
+    #[doc = "!< \"CN\" layout"]
     CN = 194,
+    #[doc = "!< \"BLOCKED\" layout"]
     BLOCKED = 200,
 }
 #[repr(u32)]
@@ -449,12 +475,18 @@ pub enum precision_e {
     FP32 = 10,
     #[doc = "< 16bit floating point value"]
     FP16 = 11,
+    #[doc = "< 64bit floating point value"]
+    FP64 = 13,
     #[doc = "< 16bit specific signed fixed point precision"]
     Q78 = 20,
     #[doc = "< 16bit signed integer value"]
     I16 = 30,
+    #[doc = "< 4bit unsigned integer value"]
+    U4 = 39,
     #[doc = "< 8bit unsigned integer value"]
     U8 = 40,
+    #[doc = "< 4bit signed integer value"]
+    I4 = 49,
     #[doc = "< 8bit signed integer value"]
     I8 = 50,
     #[doc = "< 16bit unsigned integer value"]
@@ -465,6 +497,8 @@ pub enum precision_e {
     I64 = 72,
     #[doc = "< 64bit unsigned integer value"]
     U64 = 73,
+    #[doc = "< 32bit unsigned integer value"]
+    U32 = 74,
     #[doc = "< 1bit integer value"]
     BIN = 71,
     #[doc = "< custom precision has it's own name and size of elements"]
@@ -530,19 +564,19 @@ pub type tensor_desc_t = tensor_desc;
 #[doc = " @brief Extra information about input color format for preprocessing"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum colorformat_e {
-    #[doc = "< Plain blob (default), no extra color processing required"]
+    #[doc = "!< Plain blob (default), no extra color processing required"]
     RAW = 0,
-    #[doc = "< RGB color format"]
+    #[doc = "!< RGB color format"]
     RGB = 1,
-    #[doc = "< BGR color format, default in DLDT"]
+    #[doc = "!< BGR color format, default in DLDT"]
     BGR = 2,
-    #[doc = "< RGBX color format with X ignored during inference"]
+    #[doc = "!< RGBX color format with X ignored during inference"]
     RGBX = 3,
-    #[doc = "< BGRX color format with X ignored during inference"]
+    #[doc = "!< BGRX color format with X ignored during inference"]
     BGRX = 4,
-    #[doc = "< NV12 color format represented as compound Y+UV blob"]
+    #[doc = "!< NV12 color format represented as compound Y+UV blob"]
     NV12 = 5,
-    #[doc = "< I420 color format represented as compound Y+U+V blob"]
+    #[doc = "!< I420 color format represented as compound Y+U+V blob"]
     I420 = 6,
 }
 #[repr(u32)]
@@ -550,8 +584,11 @@ pub enum colorformat_e {
 #[doc = " @brief Represents the list of supported resize algorithms."]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum resize_alg_e {
+    #[doc = "!< \"No resize\" mode"]
     NO_RESIZE = 0,
+    #[doc = "!< \"Bilinear resize\" mode"]
     RESIZE_BILINEAR = 1,
+    #[doc = "!< \"Area resize\" mode"]
     RESIZE_AREA = 2,
 }
 pub const IEStatusCode_OK: IEStatusCode = 0;
@@ -567,6 +604,7 @@ pub const IEStatusCode_RESULT_NOT_READY: IEStatusCode = -9;
 pub const IEStatusCode_NOT_ALLOCATED: IEStatusCode = -10;
 pub const IEStatusCode_INFER_NOT_STARTED: IEStatusCode = -11;
 pub const IEStatusCode_NETWORK_NOT_READ: IEStatusCode = -12;
+pub const IEStatusCode_INFER_CANCELLED: IEStatusCode = -13;
 #[doc = " @enum IEStatusCode"]
 #[doc = " @brief This enum contains codes for all possible return values of the interface functions"]
 pub type IEStatusCode = ::std::os::raw::c_int;
@@ -575,10 +613,15 @@ pub type IEStatusCode = ::std::os::raw::c_int;
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct roi {
+    #[doc = "!< ID of a roi"]
     pub id: usize,
+    #[doc = "!< W upper left coordinate of roi"]
     pub posX: usize,
+    #[doc = "!< H upper left coordinate of roi"]
     pub posY: usize,
+    #[doc = "!< W size of roi"]
     pub sizeX: usize,
+    #[doc = "!< H size of roi"]
     pub sizeY: usize,
 }
 #[test]
@@ -730,7 +773,9 @@ pub struct ie_blob_buffer {
 #[repr(C)]
 #[derive(Copy, Clone)]
 pub union ie_blob_buffer__bindgen_ty_1 {
+    #[doc = "!< buffer can be written"]
     pub buffer: *mut ::std::os::raw::c_void,
+    #[doc = "!< cbuffer is read-only"]
     pub cbuffer: *const ::std::os::raw::c_void,
 }
 #[test]

--- a/crates/openvino-sys/src/lib.rs
+++ b/crates/openvino-sys/src/lib.rs
@@ -40,9 +40,9 @@ pub mod library {
     pub use super::generated::load;
 
     /// Return the location of the shared library `openvino-sys` will link to. If compiled with
-    /// runtime linking, this will attempt to discover the location of a `inference_engine_c_api`
-    /// shared library on the system. Otherwise (with dynamic linking or compilation from source),
-    /// this relies on a static path discovered at build time.
+    /// runtime linking, this will attempt to discover the location of a `openvino_c` shared library
+    /// on the system. Otherwise (with dynamic linking or compilation from source), this relies on a
+    /// static path discovered at build time.
     ///
     /// Knowing the location of the OpenVINO libraries is critical to avoid errors, unfortunately.
     /// OpenVINO loads target-specific libraries on demand for performing inference. To do so, it
@@ -53,7 +53,7 @@ pub mod library {
     /// `find().unwrap().parent()`.
     pub fn find() -> Option<PathBuf> {
         if cfg!(feature = "runtime-linking") {
-            openvino_finder::find("inference_engine_c_api")
+            openvino_finder::find("openvino_c")
         } else {
             Some(PathBuf::from(env!("OPENVINO_LIB_PATH")))
         }

--- a/crates/openvino-sys/src/linking/runtime.rs
+++ b/crates/openvino-sys/src/linking/runtime.rs
@@ -77,7 +77,7 @@ macro_rules! link {
         /// May fail if the `openvino-finder` cannot discover the library on the current system.
         pub fn load() -> Result<(), String> {
             match crate::library::find() {
-                None => Err("Unable to find the `inference_engine_c_api` library to load".into()),
+                None => Err("Unable to find the `openvino_c` library to load".into()),
                 Some(path) => load_from(path),
             }
         }
@@ -111,10 +111,10 @@ macro_rules! link {
             pub unsafe fn $name($($pname: $pty), *) $(-> $ret)* {
                 let f = with_library(|l| {
                     l.functions.$name.expect(concat!(
-                        "`inference_engine_c_api` function not loaded: `",
+                        "`openvino_c` function not loaded: `",
                         stringify!($name)
                     ))
-                }).expect("an `inference_engine_c_api` shared library is not loaded on this thread");
+                }).expect("an `openvino_c` shared library is not loaded on this thread");
                 f($($pname), *)
             }
         )+

--- a/crates/xtask/src/codegen.rs
+++ b/crates/xtask/src/codegen.rs
@@ -157,5 +157,4 @@ impl CodegenCommand {
 const TYPES_FILE: &str = "types.rs";
 const FUNCTIONS_FILE: &str = "functions.rs";
 const DEFAULT_OUTPUT_DIRECTORY: &str = "openvino-sys/src/generated";
-const DEFAULT_HEADER_FILE: &str =
-    "openvino-sys/upstream/inference-engine/ie_bridges/c/include/c_api/ie_c_api.h";
+const DEFAULT_HEADER_FILE: &str = "openvino-sys/upstream/src/bindings/c/include/c_api/ie_c_api.h";


### PR DESCRIPTION
The 2022 release changes the names of several of the shared libraries
produced by OpenVINO as well as their directory structure. The C API is
still available, however, so this change continues to use that for the
time being instead of the newer v2.0 API.

Because of the significant changes to the release structure, there is a
decision to be made regarding backwards compatibility--e.g., using older
versions of OpenVINO with this binding crate. This change makes the
decision to stop supporting pre-2022 installations of OpenVINO in
ongoing versions of this crate: once this crate is released (`v0.4.0`),
users will have to decide whether to use this version for the newest
versions of OpenVINO or downgrade to a previously-released crate
(`v0.3.*`) for pre-2022 versions of OpenVINO.