### PR TITLE
Remove the `from-source` feature

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,28 +31,6 @@ jobs:
     - uses: actions/checkout@v2
     - uses: EmbarkStudios/cargo-deny-action@v1
 
-  # Build and test from the git-submodule-included OpenVINO source code.
-  source:
-    name: From source
-    runs-on: ubuntu-20.04
-    steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: recursive
-        lfs: true
-    - name: Checkout LFS obects
-      run: git lfs checkout
-    - name: Install system dependencies
-      run: sudo apt update && sudo apt install -y clang cmake libclang-dev gnupg2 libdrm2 libglib2.0-0 libusb-1.0-0-dev lsb-release libgtk-3-0 libtool udev unzip dos2unix
-    - name: Build (openvino-sys from source)
-      run: cargo build --verbose --features openvino-sys/from-source
-    - name: Run tests
-      # For some reason the library path is not set during the doc tests (`--doc`, see
-      # https://doc.rust-lang.org/cargo/commands/cargo-test.html#target-selection) so we skip them
-      # here: issue at https://github.com/intel/openvino-rs/issues/25. Also, the `from-source` build
-      # does not know how to run the inception SSD test.
-      run: cargo test --verbose --features openvino-sys/from-source --lib --tests -- --skip detect_inception
-
   # Build and test from an existing OpenVINO installation inside a Docker image (i.e. download the
   # binaries, then compile against these).
   dynamic_binaries:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,12 +73,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "cc"
-version = "1.0.59"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66120af515773fb005778dc07c261bd201ec8ce50bd6e7144c927753fe013381"
-
-[[package]]
 name = "cexpr"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -117,15 +111,6 @@ dependencies = [
  "textwrap",
  "unicode-width",
  "vec_map",
-]
-
-[[package]]
-name = "cmake"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -286,10 +271,10 @@ dependencies = [
 name = "openvino-sys"
 version = "0.3.3"
 dependencies = [
- "cmake",
  "lazy_static",
  "libloading",
  "openvino-finder",
+ "pretty_env_logger",
 ]
 
 [[package]]

--- a/crates/openvino-finder/src/lib.rs
+++ b/crates/openvino-finder/src/lib.rs
@@ -35,21 +35,21 @@ pub fn find(library_name: &str) -> Option<PathBuf> {
         };
     }
 
-    // Search using the `OPENVINO_INSTALL_DIR` environment variable; this may be set by users of the
-    // `openvino-rs` library.
-    if let Some(install_dir) = env::var_os(ENV_OPENVINO_INSTALL_DIR) {
-        let install_dir = PathBuf::from(install_dir);
-        for lib_dir in KNOWN_INSTALLATION_SUBDIRECTORIES {
-            let search_path = install_dir.join(lib_dir).join(&file);
-            check_and_return!(search_path);
-        }
-    }
-
     // Search using the `OPENVINO_BUILD_DIR` environment variable; this may be set by users of the
     // `openvino-rs` library.
     if let Some(build_dir) = env::var_os(ENV_OPENVINO_BUILD_DIR) {
         let install_dir = PathBuf::from(build_dir);
         for lib_dir in KNOWN_BUILD_SUBDIRECTORIES {
+            let search_path = install_dir.join(lib_dir).join(&file);
+            check_and_return!(search_path);
+        }
+    }
+
+    // Search using the `OPENVINO_INSTALL_DIR` environment variable; this may be set by users of the
+    // `openvino-rs` library.
+    if let Some(install_dir) = env::var_os(ENV_OPENVINO_INSTALL_DIR) {
+        let install_dir = PathBuf::from(install_dir);
+        for lib_dir in KNOWN_INSTALLATION_SUBDIRECTORIES {
             let search_path = install_dir.join(lib_dir).join(&file);
             check_and_return!(search_path);
         }

--- a/crates/openvino-sys/Cargo.toml
+++ b/crates/openvino-sys/Cargo.toml
@@ -30,29 +30,13 @@ libloading = {version = "0.7", optional = true }
 openvino-finder = {version = "0.3.3", path = "../openvino-finder" }
 
 [build-dependencies]
-cmake = "0.1.45"
 openvino-finder = {version = "0.3.3", path = "../openvino-finder" }
+pretty_env_logger = "0.4"
 
 [features]
-default = ["cpu"]
-
-# Plugin features: if building from source, this allows selecting which OpenVINO plugins to build.
-all = ["auto", "auto_batch", "cpu", "gpu", "gna", "hetero", "myriad", "multi"]
-auto = []
-auto_batch = []
-cpu = []
-gpu = []
-gna = []
-hetero = []
-myriad = []
-multi = []
-
 # Linking features: `build.rs` will default to dynamic linking if none is selected.
 dynamic-linking = [] # Will find and bind to an OpenVINO shared library at compile time.
 runtime-linking = ["libloading", "lazy_static"] # Will bind to an OpenVINO shared library at runtime using `load`.
-
-# Build features: `build.rs` will attempt to build OpenVINO from source and then link to this.
-from-source = []
 
 [package.metadata.docs.rs]
 features = ["runtime-linking"]


### PR DESCRIPTION
Prior to this change, the `openvino-sys` crate had the ability to build
OpenVINO from source using CMake from within its `build.rs` script. This
increased complexity in various places (documentation, `Cargo.toml`
features, `build.rs`) and was prone to breakage as OpenVINO modified its
available CMake build features.

Instead of providing a `from-source` feature to do all this, this change
documents an `OPENVINO_BUILD_DIR` environment variable that can be used
for the same purpose: once a user has built OpenVINO from source on
their system, they can provide the path to this repository for the
`openvino-sys` crate to bind to. The `openvino-finder` crate contains
the necessary paths to find the default locations of all of required
libraries.