### PR TITLE
Migrate from lazy_static to once_cell.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -250,6 +250,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+
+[[package]]
 name = "openvino"
 version = "0.4.0"
 dependencies = [
@@ -271,8 +277,8 @@ dependencies = [
 name = "openvino-sys"
 version = "0.4.0"
 dependencies = [
- "lazy_static",
  "libloading",
+ "once_cell",
  "openvino-finder",
  "pretty_env_logger",
 ]

--- a/crates/openvino-sys/Cargo.toml
+++ b/crates/openvino-sys/Cargo.toml
@@ -25,7 +25,7 @@ include = [
 links = "inference_engine_c_api"
 
 [dependencies]
-lazy_static = {version = "1.4", optional = true }
+once_cell = {version = "1.12.0", optional = true }
 libloading = {version = "0.7", optional = true }
 openvino-finder = {version = "0.4.0", path = "../openvino-finder" }
 
@@ -36,7 +36,7 @@ pretty_env_logger = "0.4"
 [features]
 # Linking features: `build.rs` will default to dynamic linking if none is selected.
 dynamic-linking = [] # Will find and bind to an OpenVINO shared library at compile time.
-runtime-linking = ["libloading", "lazy_static"] # Will bind to an OpenVINO shared library at runtime using `load`.
+runtime-linking = ["libloading", "once_cell"] # Will bind to an OpenVINO shared library at runtime using `load`.
 
 [package.metadata.docs.rs]
 features = ["runtime-linking"]

--- a/crates/openvino-sys/src/linking/runtime.rs
+++ b/crates/openvino-sys/src/linking/runtime.rs
@@ -10,7 +10,7 @@ macro_rules! link {
             }
         )+
     ) => (
-        use lazy_static::lazy_static;
+        use once_cell::sync::Lazy;
         use libloading;
         use std::path::PathBuf;
         use std::sync::Arc;
@@ -34,9 +34,7 @@ macro_rules! link {
         }
 
         // `LIBRARY` holds the shared library reference.
-        lazy_static!{
-            static ref LIBRARY: RwLock<Option<Arc<SharedLibrary>>> = RwLock::new(None);
-        }
+        static LIBRARY: Lazy<RwLock<Option<Arc<SharedLibrary>>>> = Lazy::new(|| RwLock::new(None));
 
         // Helper function for accessing the thread-local version of the library.
         fn with_library<T, F>(f: F) -> Option<T>


### PR DESCRIPTION
The Rust ecosystem is generally migrating away from lazy_static to
once_cell, for example [in wasmtime].

This patch updates openvino-sys from lazy_static to once_cell.

[in wasmtime]: https://github.com/bytecodealliance/wasmtime/pull/4368
