### PR TITLE
Fix new clippy warnings

### DIFF
--- a/crates/openvino-sys/src/linking/runtime.rs
+++ b/crates/openvino-sys/src/linking/runtime.rs
@@ -74,7 +74,7 @@ macro_rules! link {
         ///
         /// May fail if the `openvino-finder` cannot discover the library on the current system.
         pub fn load() -> Result<(), String> {
-            match crate::library::find() {
+            match $crate::library::find() {
                 None => Err("Unable to find the `openvino_c` library to load".into()),
                 Some(path) => load_from(path),
             }

--- a/crates/openvino/src/core.rs
+++ b/crates/openvino/src/core.rs
@@ -39,7 +39,10 @@ impl Core {
             Some(f) => f.to_string(),
         };
         let mut instance = std::ptr::null_mut();
-        try_unsafe!(ie_core_create(cstr!(file), &mut instance as *mut *mut _))?;
+        try_unsafe!(ie_core_create(
+            cstr!(file),
+            std::ptr::addr_of_mut!(instance)
+        ))?;
         Ok(Core { instance })
     }
 
@@ -55,7 +58,7 @@ impl Core {
             self.instance,
             cstr!(model_path),
             cstr!(weights_path),
-            &mut instance as *mut *mut _,
+            std::ptr::addr_of_mut!(instance)
         ))?;
         Ok(CNNNetwork { instance })
     }
@@ -75,7 +78,7 @@ impl Core {
             model_content.as_ptr().cast::<u8>(),
             model_content.len(),
             weights_blob.instance,
-            &mut instance as *mut *mut _,
+            std::ptr::addr_of_mut!(instance)
         ))?;
         Ok(CNNNetwork { instance })
     }
@@ -99,8 +102,8 @@ impl Core {
             self.instance,
             network.instance,
             cstr!(device),
-            &empty_config as *const _,
-            &mut instance as *mut *mut _
+            std::ptr::addr_of!(empty_config),
+            std::ptr::addr_of_mut!(instance)
         ))?;
         Ok(ExecutableNetwork { instance })
     }

--- a/crates/openvino/src/error.rs
+++ b/crates/openvino/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 /// [`IEStatusCode`](https://docs.openvinotoolkit.org/latest/ie_c_api/ie__c__api_8h.html#a391683b1e8e26df8b58d7033edd9ee83).
 // TODO This could be auto-generated (https://github.com/intel/openvino-rs/issues/20).
 #[allow(missing_docs)]
-#[derive(Debug, Error, PartialEq)]
+#[derive(Debug, Error, PartialEq, Eq)]
 pub enum InferenceError {
     #[error("general error")]
     GeneralError,

--- a/crates/openvino/src/lib.rs
+++ b/crates/openvino/src/lib.rs
@@ -53,6 +53,6 @@ pub fn version() -> String {
     let str_version = unsafe { CStr::from_ptr(ie_version.api_version) }
         .to_string_lossy()
         .into_owned();
-    unsafe { openvino_sys::ie_version_free(&mut ie_version as *mut openvino_sys::ie_version_t) };
+    unsafe { openvino_sys::ie_version_free(std::ptr::addr_of_mut!(ie_version)) };
     str_version
 }

--- a/crates/openvino/src/network.rs
+++ b/crates/openvino/src/network.rs
@@ -42,12 +42,12 @@ impl CNNNetwork {
         try_unsafe!(ie_network_get_input_name(
             self.instance,
             index,
-            &mut c_name as *mut *mut _
+            std::ptr::addr_of_mut!(c_name)
         ))?;
         let rust_name = unsafe { CStr::from_ptr(c_name) }
             .to_string_lossy()
             .into_owned();
-        unsafe { ie_network_name_free(&mut c_name as *mut *mut _) };
+        unsafe { ie_network_name_free(std::ptr::addr_of_mut!(c_name)) };
         debug_assert!(c_name.is_null());
         Ok(rust_name)
     }
@@ -58,12 +58,12 @@ impl CNNNetwork {
         try_unsafe!(ie_network_get_output_name(
             self.instance,
             index,
-            &mut c_name as *mut *mut _
+            std::ptr::addr_of_mut!(c_name)
         ))?;
         let rust_name = unsafe { CStr::from_ptr(c_name) }
             .to_string_lossy()
             .into_owned();
-        unsafe { ie_network_name_free(&mut c_name as *mut *mut _) };
+        unsafe { ie_network_name_free(std::ptr::addr_of_mut!(c_name)) };
         debug_assert!(c_name.is_null());
         Ok(rust_name)
     }
@@ -122,7 +122,7 @@ impl ExecutableNetwork {
         let mut instance = std::ptr::null_mut();
         try_unsafe!(ie_exec_network_create_infer_request(
             self.instance,
-            &mut instance as *mut *mut _
+            std::ptr::addr_of_mut!(instance)
         ))?;
         Ok(InferRequest { instance })
     }

--- a/crates/openvino/src/request.rs
+++ b/crates/openvino/src/request.rs
@@ -33,7 +33,7 @@ impl InferRequest {
         try_unsafe!(ie_infer_request_get_blob(
             self.instance,
             cstr!(name),
-            &mut instance as *mut *mut _
+            std::ptr::addr_of_mut!(instance)
         ))?;
         Ok(unsafe { Blob::from_raw_pointer(instance) })
     }

--- a/crates/openvino/src/util.rs
+++ b/crates/openvino/src/util.rs
@@ -18,7 +18,7 @@ macro_rules! cstr {
 #[macro_export]
 macro_rules! try_unsafe {
     ($e: expr) => {
-        crate::InferenceError::from(unsafe { $e })
+        $crate::InferenceError::from(unsafe { $e })
     };
 }
 


### PR DESCRIPTION
A new version of Rust has introduced several new lints: this fixes the use of `$crate` in macros (an error) and uses `std::ptr::addr_of_mut!` in a variety of places (a warning).