### PR TITLE
ci: pin GitHub runner to Ubuntu 20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
   # commands.
   converter:
     name: Converter tool
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: crates/openvino-tensor-converter

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
   # binaries, then compile against these).
   runtime_binaries:
     name: From runtime-linked binaries
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
As noted in GitHub's [supported runners] documentation, GitHub is in the process of transitioning `ubuntu-latest` from `ubuntu-20.04` to `ubuntu-22.04` (jammy). Since OpenVINO does not yet have installation packages for Ubuntu 22.04, this change pins the GitHub runner to the older version for now.

[supported runners]: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources