### PR TITLE
Double-check size of returned blob dimensions

### DIFF
--- a/crates/openvino/src/blob.rs
+++ b/crates/openvino/src/blob.rs
@@ -63,7 +63,7 @@ impl Blob {
         // auto-generated in the bindings; see `struct dimensions` in
         // `openvino-sys/src/generated/types.rs`. It is not clear to me whether this will return the
         // statically-expected size or the dynamic size -- this is not effective in the former case.
-        assert_eq!(unsafe { dimensions.assume_init() }.len(), 8);
+        assert_eq!(unsafe { dimensions.assume_init() }.dims.len(), 8);
 
         let mut precision = MaybeUninit::uninit();
         try_unsafe!(ie_blob_get_precision(blob, precision.as_mut_ptr()))?;

--- a/crates/openvino/src/blob.rs
+++ b/crates/openvino/src/blob.rs
@@ -58,6 +58,14 @@ impl Blob {
 
         let mut dimensions = MaybeUninit::uninit();
         try_unsafe!(ie_blob_get_dims(blob, dimensions.as_mut_ptr()))?;
+        // Safety: this assertion is trying to avoid the improbable case where some future version
+        // of the OpenVINO library returns a dimensions array with size different than the one
+        // auto-generated in the bindings; see `struct dimensions` in
+        // `openvino-sys/src/generated/types.rs`.
+        assert_eq!(
+            dimensions.as_bytes().len(),
+            8 * std::mem::size_of::<usize>()
+        );
 
         let mut precision = MaybeUninit::uninit();
         try_unsafe!(ie_blob_get_precision(blob, precision.as_mut_ptr()))?;

--- a/crates/openvino/src/blob.rs
+++ b/crates/openvino/src/blob.rs
@@ -61,11 +61,9 @@ impl Blob {
         // Safety: this assertion is trying to avoid the improbable case where some future version
         // of the OpenVINO library returns a dimensions array with size different than the one
         // auto-generated in the bindings; see `struct dimensions` in
-        // `openvino-sys/src/generated/types.rs`.
-        assert_eq!(
-            dimensions.as_bytes().len(),
-            8 * std::mem::size_of::<usize>()
-        );
+        // `openvino-sys/src/generated/types.rs`. It is not clear to me whether this will return the
+        // statically-expected size or the dynamic size -- this is not effective in the former case.
+        assert_eq!(unsafe { dimensions.assume_init() }.len(), 8);
 
         let mut precision = MaybeUninit::uninit();
         try_unsafe!(ie_blob_get_precision(blob, precision.as_mut_ptr()))?;


### PR DESCRIPTION
As discussed [here], this change adds a (perhaps overkill) safety check of the size of the dimensions array returned by the OpenVINO library. The added assertion is trying to avoid the improbable case where some future version of the OpenVINO library returns a dimensions array with size different than the one auto-generated in the bindings; see `struct dimensions` in `openvino-sys/src/generated/types.rs`.

[here]: https://github.com/intel/openvino-rs/pull/56#discussion_r1041570646