### PR TITLE
ci: build against more versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,37 +40,36 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu18, ubuntu20]
-        version: [2022.1.0]
+        version: [2022.1.0, 2022.2.0, 2022.3.0]
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         lfs: true
-    - name: Checkout LFS obects
+    - name: Checkout LFS objects
       run: git lfs checkout
     - name: Build the Docker image
       run: docker build . --tag openvino-rs:${{ matrix.OS }}-${{ matrix.version }}-$(date +%s) --build-arg OS=${{ matrix.os }} --build-arg VERSION=${{ matrix.version }}
 
-  # Build and test from an existing OpenVINO installation inside a Docker image (i.e. download the
-  # binaries, then compile against these).
+  # Build and test from an existing OpenVINO installation from an archive installed on the
+  # filesystem.
   runtime_binaries:
     name: From runtime-linked binaries
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
         lfs: true
-    - name: Checkout LFS obects
+    - name: Checkout LFS objects
       run: git lfs checkout
-    - uses: abrown/install-openvino-action@v3
+    - uses: abrown/install-openvino-action@v6
+      with:
+        apt: true
     - name: Build and run tests
-      run: |
-        source /opt/intel/openvino_2022/setupvars.sh
-        cargo test --features openvino-sys/runtime-linking
+      run: cargo test --features openvino-sys/runtime-linking
 
-  # Build and test from an existing OpenVINO installation inside a Docker image (i.e. download the
-  # binaries, then compile against these).
+  # Check that the documentation builds.
   docs:
     name: Documentation
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ name = "openvino"
 version = "0.4.2"
 dependencies = [
  "float-cmp",
+ "openvino-finder",
  "openvino-sys",
  "thiserror",
 ]

--- a/crates/openvino-sys/build.rs
+++ b/crates/openvino-sys/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::{Path, PathBuf};
 
 // These are the libraries we expect to be available to dynamically link to:
-const LIBRARIES: &[&str] = &["openvino", "openvino_c", "tbb"];
+const LIBRARIES: &[&str] = &["openvino", "openvino_c"];
 
 // A user-specified environment variable indicating that `build.rs` should not attempt to link
 // against any libraries (e.g. a doc build, user may link them later).

--- a/crates/openvino/Cargo.toml
+++ b/crates/openvino/Cargo.toml
@@ -16,6 +16,7 @@ exclude = [
 
 [dependencies]
 openvino-sys = { path = "../openvino-sys", version = "0.4.2" }
+openvino-finder = { path = "../openvino-finder", version = "0.4.2" }
 thiserror = "1.0.20"
 
 [dev-dependencies]

--- a/crates/openvino/src/core.rs
+++ b/crates/openvino/src/core.rs
@@ -30,14 +30,11 @@ impl Core {
         openvino_sys::library::load().map_err(LoadingError::SystemFailure)?;
 
         let file = match xml_config_file {
-            None => format!(
-                "{}/plugins.xml",
-                openvino_sys::library::find()
-                    .ok_or(LoadingError::CannotFindPath)?
-                    .parent()
-                    .ok_or(LoadingError::NoParentDirectory)?
-                    .display()
-            ),
+            None => openvino_finder::find_plugins_xml()
+                .ok_or(LoadingError::CannotFindPluginPath)?
+                .to_str()
+                .ok_or(LoadingError::CannotStringifyPath)?
+                .to_string(),
             Some(f) => f.to_string(),
         };
         let mut instance = std::ptr::null_mut();

--- a/crates/openvino/src/error.rs
+++ b/crates/openvino/src/error.rs
@@ -79,7 +79,9 @@ pub enum LoadingError {
     #[error("system failed to load shared libraries (see https://github.com/intel/openvino-rs/blob/main/crates/openvino-finder): {0}")]
     SystemFailure(String),
     #[error("cannot find path to shared libraries (see https://github.com/intel/openvino-rs/blob/main/crates/openvino-finder)")]
-    CannotFindPath,
-    #[error("no parent directory found for shared library path")]
-    NoParentDirectory,
+    CannotFindLibraryPath,
+    #[error("cannot find path to XML plugin configuration (see https://github.com/intel/openvino-rs/blob/main/crates/openvino-finder)")]
+    CannotFindPluginPath,
+    #[error("unable to convert path to a UTF-8 string (see https://doc.rust-lang.org/std/path/struct.Path.html#method.to_str)")]
+    CannotStringifyPath,
 }


### PR DESCRIPTION
Now that OpenVINO 2022.3 is released, this updates the CI to use it during the build and test tasks.