### PR TITLE
Check crates in more environments

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,6 +69,30 @@ jobs:
     - name: Build and run tests
       run: cargo test --features openvino-sys/runtime-linking
 
+  # Check that libraries can be found
+  test:
+    name: From runtime-linked binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, ubuntu-22.04, macos-latest, windows-latest]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        lfs: true
+    - name: Checkout LFS objects
+      run: git lfs checkout
+    - uses: abrown/install-openvino-action@v6
+    - name: List files
+      run: find $OPENVINO_INSTALL_DIR
+      shell: bash
+    - name: Build and run tests
+      run: cargo test --features openvino-sys/runtime-linking
+      env:
+        RUST_LOG: debug
+        RUST_BACKTRACE: 1
+
   # Check that the documentation builds.
   docs:
     name: Documentation

--- a/crates/openvino-finder/src/lib.rs
+++ b/crates/openvino-finder/src/lib.rs
@@ -210,8 +210,12 @@ cfg_if! {
     }
 }
 
-const KNOWN_INSTALLATION_SUBDIRECTORIES: &[&str] =
-    &["runtime/lib/intel64", "runtime/3rdparty/tbb/lib"];
+const KNOWN_INSTALLATION_SUBDIRECTORIES: &[&str] = &[
+    "runtime/lib/intel64",
+    "runtime/3rdparty/tbb/lib",
+    "runtime/bin/intel64",
+    "runtime/3rdparty/tbb/bin",
+];
 
 const KNOWN_BUILD_SUBDIRECTORIES: &[&str] = &[
     "bin/intel64/Debug/lib",


### PR DESCRIPTION
Previously, the tests were only run in a subset of these environments. This PR will attempt to check that the tests run in a more exhaustive set of CI environments.