### PR TITLE
Return error information for variants of `SetupError`

### DIFF
--- a/crates/openvino/src/error.rs
+++ b/crates/openvino/src/error.rs
@@ -66,9 +66,9 @@ impl InferenceError {
 #[allow(missing_docs)]
 #[derive(Debug, Error)]
 pub enum SetupError {
-    #[error("inference error")]
+    #[error("inference error: {0}")]
     Inference(#[from] InferenceError),
-    #[error("library loading error")]
+    #[error("library loading error: {0}")]
     Loading(#[from] LoadingError),
 }
 


### PR DESCRIPTION
`Inference` and `Loading` variants of `SetupError` carry more information about the error that was returned, bubble it up so that we provide more information about the error that is being returned.