### PR TITLE
fix: clippy warnings

### DIFF
--- a/crates/openvino-finder/src/lib.rs
+++ b/crates/openvino-finder/src/lib.rs
@@ -25,14 +25,14 @@
 //! If you do run into problems, the following chart summarizes some of the known installation
 //! locations of the OpenVINO files as of version `2022.3.0`:
 //!
-//! | Installation Method | Path                                               | Available on          | Notes                            |
-//! | ------------------- | -------------------------------------------------- | --------------------- | -------------------------------- |
-//! | Archive (`.tar.gz`) | `<extracted folder>/runtime/lib/<arch>`            | Linux                 | `<arch>`: `intel64,armv7l,arm64` |
-//! | Archive (`.tar.gz`) | `<extracted folder>/runtime/lib/<arch>/Release`    | MacOS                 | `<arch>`: `intel64,armv7l,arm64` |
-//! | Archive (`.zip`)    | `<unzipped folder>/runtime/bin/<arch>/Release`     | Windows               | `<arch>`: `intel64,armv7l,arm64` |
-//! | PyPI                | `<pip install folder>/site-packages/openvino/libs` | Linux, MacOS, Windows | Find install folder with `pip show openvino` |
-//! | DEB                 | `/usr/lib/x86_64-linux-gnu/openvino-<version>/`    | Linux (APT-based)     | This path is for plugins; the libraries are one directory above |
-//! | RPM                 | `/usr/lib64/`                                      | Linux (YUM-based)     |                                  |
+//! | Installation Method | Path                                               | Available on            | Notes                            |
+//! | ------------------- | -------------------------------------------------- | ----------------------- | -------------------------------- |
+//! | Archive (`.tar.gz`) | `<extracted folder>/runtime/lib/<arch>`            | Linux                   | `<arch>`: `intel64,armv7l,arm64` |
+//! | Archive (`.tar.gz`) | `<extracted folder>/runtime/lib/<arch>/Release`    | `MacOS`                 | `<arch>`: `intel64,armv7l,arm64` |
+//! | Archive (`.zip`)    | `<unzipped folder>/runtime/bin/<arch>/Release`     | Windows                 | `<arch>`: `intel64,armv7l,arm64` |
+//! | `PyPI`              | `<pip install folder>/site-packages/openvino/libs` | Linux, `MacOS`, Windows | Find install folder with `pip show openvino` |
+//! | DEB                 | `/usr/lib/x86_64-linux-gnu/openvino-<version>/`    | Linux (APT-based)       | This path is for plugins; the libraries are one directory above |
+//! | RPM                 | `/usr/lib64/`                                      | Linux (YUM-based)       |                                  |
 
 #![deny(missing_docs)]
 #![deny(clippy::all)]
@@ -56,6 +56,8 @@ macro_rules! check_and_return {
     };
 }
 
+/// # Panics
+///
 /// Find the path to an OpenVINO library.
 ///
 /// Because OpenVINO can be installed in quite a few ways (see module documentation), this function
@@ -295,7 +297,7 @@ fn build_latest_version(dir: &Path, prefix: &str, mut versions: Vec<String>) -> 
     let latest_version = versions
         .first()
         .expect("already checked that a version exists");
-    let filename = format!("{}{}", prefix, latest_version);
+    let filename = format!("{prefix}{latest_version}");
     Some(dir.join(filename))
 }
 

--- a/crates/openvino/src/blob.rs
+++ b/crates/openvino/src/blob.rs
@@ -57,7 +57,7 @@ impl Blob {
     /// dimensions array with a size different than the one auto-generated in the bindings; see
     /// `struct dimensions` in `openvino-sys/src/generated/types.rs`.
     pub fn tensor_desc(&self) -> Result<TensorDesc> {
-        let blob = self.instance as *const ie_blob_t;
+        let blob = self.instance.cast_const();
 
         let mut layout = MaybeUninit::uninit();
         try_unsafe!(ie_blob_get_layout(blob, layout.as_mut_ptr()))?;

--- a/crates/openvino/src/core.rs
+++ b/crates/openvino/src/core.rs
@@ -37,7 +37,7 @@ impl Core {
                 .ok_or(LoadingError::CannotStringifyPath)?
                 .to_string())
         } else {
-            cstr!("".to_string())
+            cstr!(String::new())
         };
 
         let mut instance = std::ptr::null_mut();

--- a/crates/openvino/src/lib.rs
+++ b/crates/openvino/src/lib.rs
@@ -45,6 +45,8 @@ pub use openvino_sys::{
 pub use request::InferRequest;
 pub use tensor_desc::TensorDesc;
 
+/// # Panics
+///
 /// Emit the version string of the OpenVINO C API backing this implementation.
 pub fn version() -> String {
     use std::ffi::CStr;

--- a/crates/xtask/src/bump.rs
+++ b/crates/xtask/src/bump.rs
@@ -31,10 +31,10 @@ impl BumpCommand {
             .windows(2)
             .all(|w| w[0].version == w[1].version)
         {
-            anyhow!(
+            return Err(anyhow!(
                 "Not all crate versions are the same: {:?}",
                 publishable_crates
-            );
+            ));
         }
 
         // Change the version. Unless specified with a custom version, the `pre` and `build`
@@ -70,7 +70,7 @@ impl BumpCommand {
         }
 
         // Add a Git commit.
-        let commit_message = format!("Release v{}", next_version_str);
+        let commit_message = format!("Release v{next_version_str}");
         if self.git {
             println!("> add Git commit: {}", &commit_message);
             if !self.dry_run && self.git {

--- a/crates/xtask/src/publish.rs
+++ b/crates/xtask/src/publish.rs
@@ -25,10 +25,10 @@ impl PublishCommand {
             .windows(2)
             .all(|w| w[0].version == w[1].version)
         {
-            anyhow!(
+            return Err(anyhow!(
                 "Not all crate versions are the same: {:?}",
                 publishable_crates
-            );
+            ));
         }
 
         // Check that all of the publishable crates are in `PUBLICATION_ORDER`.
@@ -40,7 +40,7 @@ impl PublishCommand {
         // Publish each crate.
         let crates_dir = path_to_crates()?;
         for krate in PUBLICATION_ORDER {
-            println!("> publish {}", krate);
+            println!("> publish {krate}");
             if !self.dry_run {
                 let krate_dir = crates_dir.clone().join(krate);
                 let exec_result = exec(
@@ -53,7 +53,7 @@ impl PublishCommand {
                 // We want to continue even if a crate does not publish: this allows us to re-run
                 // the `publish` command if uploading one or more crates fails.
                 if let Err(e) = exec_result {
-                    println!("Failed to publish crate {}, continuing:\n  {}", krate, e);
+                    println!("Failed to publish crate {krate}, continuing:\n  {e}");
                 }
 
                 // Hopefully this gives crates.io enough time for subsequent publications to work.
@@ -64,7 +64,7 @@ impl PublishCommand {
         // Tag the repository.
         let tag = format!("v{}", publishable_crates[0].version);
         if self.git {
-            println!("> push Git tag: {}", tag);
+            println!("> push Git tag: {tag}");
             if !self.dry_run {
                 exec(Command::new("git").arg("tag").arg(&tag))?;
                 exec(Command::new("git").arg("push").arg("origin").arg(&tag))?;


### PR DESCRIPTION
fix: clippy warnings and missing error return

A couple of these looked like actual bugs, where an `anyhow!` error was generated but not returned