### PR TITLE
ci: prevent `GITHUB_TOKEN` from modifying the repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,5 @@
 name: CI
+permissions: read-all
 
 on:
   push:


### PR DESCRIPTION
This change ostensibly protects the repository from CI attacks by limiting wha the `GITHUB_TOKEN` can do. See the token permissions documentation at:
- [OpenSSF]
- [GitHub]

[OpenSSF]: https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions
[GitHub]: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions