### PR TITLE
patch:  add async inference api functions inteface

### DIFF
--- a/crates/openvino/src/request.rs
+++ b/crates/openvino/src/request.rs
@@ -3,6 +3,7 @@ use crate::{cstr, drop_using_function, try_unsafe, util::Result};
 use openvino_sys::{
     ie_infer_request_free, ie_infer_request_get_blob, ie_infer_request_infer,
     ie_infer_request_set_batch, ie_infer_request_set_blob, ie_infer_request_t,
+    ie_infer_request_infer_async, ie_infer_request_wait,
 };
 
 /// See
@@ -44,5 +45,15 @@ impl InferRequest {
     /// Execute the inference request.
     pub fn infer(&mut self) -> Result<()> {
         try_unsafe!(ie_infer_request_infer(self.instance))
+    }
+
+    /// Execute the inference request asyncroneously.
+    pub fn infer_async(&mut self) -> Result<()> {
+        try_unsafe!(ie_infer_request_infer_async(self.instance))
+    }
+
+    /// Wait for the result of the inference asyncroneous request.
+    pub fn wait(&mut self, timeout: i64) -> Result<()> {
+        try_unsafe!(ie_infer_request_wait(self.instance, timeout))
     }
 }


### PR DESCRIPTION
It looks like [async inference api](https://docs.openvino.ai/2023.3/notebooks/115-async-api-with-output.html#async-mode) is exposed from C library [by openvino-sys](https://github.com/intel/openvino-rs/blob/7599a31cc5c7083edd1425e2fd577d9cae588045/crates/openvino-sys/src/generated/functions.rs#L234-L251), but these methods are not exposed to rust users of openvino crate.
This patch adds couple of methods, so one could start using async api without calling openvino-sys methods directly.