### PR TITLE
Refactor the pre-processing pipeline

### DIFF
--- a/crates/openvino/tests/classify-alexnet.rs
+++ b/crates/openvino/tests/classify-alexnet.rs
@@ -30,18 +30,18 @@ fn classify_alexnet() -> anyhow::Result<()> {
     // Pre-process the input by:
     // - converting NHWC to NCHW
     // - resizing the input image
-    let pre_post_process = prepostprocess::PrePostProcess::new(&mut model)?;
+    let pre_post_process = prepostprocess::Pipeline::new(&mut model)?;
     let input_info = pre_post_process.get_input_info_by_name("data")?;
-    let mut input_tensor_info = input_info.preprocess_input_info_get_tensor_info()?;
-    input_tensor_info.preprocess_input_tensor_set_from(&tensor)?;
-    input_tensor_info.preprocess_input_tensor_set_layout(&Layout::new("NHWC")?)?;
-    let mut preprocess_steps = input_info.get_preprocess_steps()?;
-    preprocess_steps.preprocess_steps_resize(ResizeAlgorithm::Linear)?;
-    let model_info = input_info.get_model_info()?;
-    model_info.model_info_set_layout(&Layout::new("NCHW")?)?;
+    let mut input_tensor_info = input_info.get_tensor_info()?;
+    input_tensor_info.set_from(&tensor)?;
+    input_tensor_info.set_layout(&Layout::new("NHWC")?)?;
+    let mut steps = input_info.get_steps()?;
+    steps.resize(ResizeAlgorithm::Linear)?;
+    let mut model_info = input_info.get_model_info()?;
+    model_info.set_layout(&Layout::new("NCHW")?)?;
     let output_info = pre_post_process.get_output_info_by_index(0)?;
-    let output_tensor_info = output_info.get_output_info_get_tensor_info()?;
-    output_tensor_info.preprocess_set_element_type(ElementType::F32)?;
+    let mut output_tensor_info = output_info.get_tensor_info()?;
+    output_tensor_info.set_element_type(ElementType::F32)?;
     let new_model = pre_post_process.build_new_model()?;
 
     // Compile the model and infer the results.

--- a/crates/openvino/tests/classify-inception.rs
+++ b/crates/openvino/tests/classify-inception.rs
@@ -30,15 +30,15 @@ fn classify_inception() -> anyhow::Result<()> {
     // Pre-process the input by:
     // - converting NHWC to NCHW
     // - resizing the input image
-    let pre_post_process = prepostprocess::PrePostProcess::new(&mut model)?;
+    let pre_post_process = prepostprocess::Pipeline::new(&mut model)?;
     let input_info = pre_post_process.get_input_info_by_name("input")?;
-    let mut input_tensor_info = input_info.preprocess_input_info_get_tensor_info()?;
-    input_tensor_info.preprocess_input_tensor_set_from(&tensor)?;
-    input_tensor_info.preprocess_input_tensor_set_layout(&Layout::new("NHWC")?)?;
-    let mut preprocess_steps = input_info.get_preprocess_steps()?;
-    preprocess_steps.preprocess_steps_resize(ResizeAlgorithm::Linear)?;
-    let model_info = input_info.get_model_info()?;
-    model_info.model_info_set_layout(&Layout::new("NCHW")?)?;
+    let mut input_tensor_info = input_info.get_tensor_info()?;
+    input_tensor_info.set_from(&tensor)?;
+    input_tensor_info.set_layout(&Layout::new("NHWC")?)?;
+    let mut steps = input_info.get_steps()?;
+    steps.resize(ResizeAlgorithm::Linear)?;
+    let mut model_info = input_info.get_model_info()?;
+    model_info.set_layout(&Layout::new("NCHW")?)?;
     let new_model = pre_post_process.build_new_model()?;
 
     // Compile the model and infer the results.

--- a/crates/openvino/tests/classify-mobilenet.rs
+++ b/crates/openvino/tests/classify-mobilenet.rs
@@ -30,18 +30,18 @@ fn classify_mobilenet() -> anyhow::Result<()> {
     // Pre-process the input by:
     // - converting NHWC to NCHW
     // - resizing the input image
-    let pre_post_process = prepostprocess::PrePostProcess::new(&mut model)?;
+    let pre_post_process = prepostprocess::Pipeline::new(&mut model)?;
     let input_info = pre_post_process.get_input_info_by_name("input")?;
-    let mut input_tensor_info = input_info.preprocess_input_info_get_tensor_info()?;
-    input_tensor_info.preprocess_input_tensor_set_from(&tensor)?;
-    input_tensor_info.preprocess_input_tensor_set_layout(&Layout::new("NHWC")?)?;
-    let mut preprocess_steps = input_info.get_preprocess_steps()?;
-    preprocess_steps.preprocess_steps_resize(ResizeAlgorithm::Linear)?;
-    let model_info = input_info.get_model_info()?;
-    model_info.model_info_set_layout(&Layout::new("NCHW")?)?;
+    let mut input_tensor_info = input_info.get_tensor_info()?;
+    input_tensor_info.set_from(&tensor)?;
+    input_tensor_info.set_layout(&Layout::new("NHWC")?)?;
+    let mut steps = input_info.get_steps()?;
+    steps.resize(ResizeAlgorithm::Linear)?;
+    let mut model_info = input_info.get_model_info()?;
+    model_info.set_layout(&Layout::new("NCHW")?)?;
     let output_info = pre_post_process.get_output_info_by_index(0)?;
-    let output_tensor_info = output_info.get_output_info_get_tensor_info()?;
-    output_tensor_info.preprocess_set_element_type(ElementType::F32)?;
+    let mut output_tensor_info = output_info.get_tensor_info()?;
+    output_tensor_info.set_element_type(ElementType::F32)?;
     let new_model = pre_post_process.build_new_model()?;
 
     // Compile the model and infer the results.


### PR DESCRIPTION
This change refactors the `prepostprocess` module by moving code around, renaming things, and eliminating some extra code. The one key change to look out for that is not trivial is the switch to use `&mut self` for functions that use `*mut ...` pointers. This makes use of Rust's builtin borrow checking to avoid concurrent mutable access to the OpenVINO internal objects, which is hidden away by our `unsafe` FFI calls.