### PR TITLE
Update CI to remove old openvino versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,10 +25,12 @@ jobs:
         apt: [false]
         # We also spot-check that things work when installing from APT by adding to the matrix: see
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
+        # APT install and check oldest supported version 2023.2.0
         include:
           - os: ubuntu-22.04
             version: 2023.2.0
             apt: true
+        # APT install and check latest supported version 2024.1.0
         include:
           - os: ubuntu-22.04
             version: 2024.1.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,10 +28,9 @@ jobs:
         # APT install and check oldest supported version 2023.2.0
         include:
           - os: ubuntu-22.04
-            version: 2023.2.0
+            version: 2022.3.0
             apt: true
         # APT install and check latest supported version 2024.1.0
-        include:
           - os: ubuntu-22.04
             version: 2024.1.0
             apt: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,13 +21,17 @@ jobs:
         # found ("dyld: Library not loaded; '@rpath/libopenvino.2310.dylib'"). See
         # https://github.com/abrown/openvino-rs/actions/runs/6423141936/job/17441022932#step:7:154
         os: [ubuntu-20.04, ubuntu-22.04, windows-latest]
-        version: [2022.3.0, 2023.1.0, 2023.2.0, 2024.0.0]
+        version: [2023.2.0, 2024.0.0, 2024.1.0]
         apt: [false]
         # We also spot-check that things work when installing from APT by adding to the matrix: see
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         include:
           - os: ubuntu-22.04
-            version: 2024.0.0
+            version: 2023.2.0
+            apt: true
+        include:
+          - os: ubuntu-22.04
+            version: 2024.1.0
             apt: true
     env:
       RUST_LOG: debug

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         include:
           - os: ubuntu-22.04
             version: 2022.3.0
-            apt: true
+            apt: false
         # APT install and check latest supported version 2024.1.0
           - os: ubuntu-22.04
             version: 2024.1.0


### PR DESCRIPTION
- Removed older openvino versions supported from CI 2023.1.0 and 2022.3.0
- Added newer openvino versions supported in CI 2024.1.0
- Added apt install and check for oldest (along with newest) supported versions i.e. 2023.2.0 and 2024.1.0 here