### PR TITLE
Support loading non-string models from memory

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,12 +25,8 @@ jobs:
         apt: [false]
         # We also spot-check that things work when installing from APT by adding to the matrix: see
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
-        # APT install and check oldest supported version 2023.2.0
-        include:
-          - os: ubuntu-22.04
-            version: 2022.3.0
-            apt: false
         # APT install and check latest supported version 2024.1.0
+        include:
           - os: ubuntu-22.04
             version: 2024.1.0
             apt: true

--- a/crates/openvino/src/core.rs
+++ b/crates/openvino/src/core.rs
@@ -53,19 +53,17 @@ impl Core {
     }
 
     /// Read model with model and weights loaded in memory.
-    pub fn read_model_from_buffer<'a, T: Into<Option<&'a Tensor>>>(
+    pub fn read_model_from_buffer(
         &mut self,
         model_str: &[u8],
-        weights_buffer: T,
+        weights_buffer: Option<&Tensor>,
     ) -> Result<Model> {
         let mut ptr = std::ptr::null_mut();
         try_unsafe!(ov_core_read_model_from_memory_buffer(
             self.ptr,
             model_str.as_ptr().cast::<c_char>(),
             model_str.len(),
-            weights_buffer
-                .into()
-                .map_or(std::ptr::null(), |tensor| tensor.as_ptr().cast_const()),
+            weights_buffer.map_or(std::ptr::null(), |tensor| tensor.as_ptr().cast_const()),
             std::ptr::addr_of_mut!(ptr)
         ))?;
         Ok(Model::from_ptr(ptr))


### PR DESCRIPTION
We've run into an issue with `Core::read_model_from_buffer` -- the wrapper assumes that the in-memory model is a valid string. However, non-native models, such as ONNX, aren't valid strings. Attempting to load an ONNX model results in an error creating a CString due to non-terminating null characters.

We propose to change the method interface to support arbitrary byte models rather than just strings.

Furthermore, we propose to make the weight tensor an optional argument, as it doesn't apply to non-native models.
