### PR TITLE
Replace variadic arguments with fixed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,7 @@ dependencies = [
  "anyhow",
  "bindgen",
  "clap",
+ "regex",
  "semver",
  "toml",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.5"
+version = "1.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
+checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -461,9 +461,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.8"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -472,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
 
 [[package]]
 name = "rustc-hash"

--- a/crates/openvino-sys/src/generated/functions.rs
+++ b/crates/openvino-sys/src/generated/functions.rs
@@ -641,7 +641,7 @@ extern "C" {
     pub fn ov_compiled_model_set_property(
         compiled_model: *const ov_compiled_model_t,
         property_key: *const ::std::os::raw::c_char,
-		property_value: *const ::std::os::raw::c_char
+	property_value: *const ::std::os::raw::c_char
     ) -> ov_status_e;
 }
 extern "C" {
@@ -767,7 +767,7 @@ extern "C" {
         core: *const ov_core_t,
         device_name: *const ::std::os::raw::c_char,
         property_key: *const ::std::os::raw::c_char,
-		property_value: *const ::std::os::raw::c_char
+	property_value: *const ::std::os::raw::c_char
     ) -> ov_status_e;
 }
 extern "C" {

--- a/crates/openvino-sys/src/generated/functions.rs
+++ b/crates/openvino-sys/src/generated/functions.rs
@@ -641,7 +641,7 @@ extern "C" {
     pub fn ov_compiled_model_set_property(
         compiled_model: *const ov_compiled_model_t,
         property_key: *const ::std::os::raw::c_char,
-	property_value: *const ::std::os::raw::c_char
+        property_value: *const ::std::os::raw::c_char
     ) -> ov_status_e;
 }
 extern "C" {
@@ -767,7 +767,7 @@ extern "C" {
         core: *const ov_core_t,
         device_name: *const ::std::os::raw::c_char,
         property_key: *const ::std::os::raw::c_char,
-	property_value: *const ::std::os::raw::c_char
+        property_value: *const ::std::os::raw::c_char
     ) -> ov_status_e;
 }
 extern "C" {

--- a/crates/openvino-sys/src/generated/functions.rs
+++ b/crates/openvino-sys/src/generated/functions.rs
@@ -640,7 +640,8 @@ extern "C" {
     #[doc = " @brief Sets properties for a device, acceptable keys can be found in ov_property_key_xxx.\n @ingroup ov_compiled_model_c_api\n @param compiled_model A pointer to the ov_compiled_model_t.\n @param ... variadic paramaters The format is <char *property_key, char* property_value>.\n Supported property key please see ov_property.h.\n @return Status code of the operation: OK(0) for success."]
     pub fn ov_compiled_model_set_property(
         compiled_model: *const ov_compiled_model_t,
-        ...
+        property_key: *const ::std::os::raw::c_char,
+        property_value: *const ::std::os::raw::c_char
     ) -> ov_status_e;
 }
 extern "C" {
@@ -765,7 +766,8 @@ extern "C" {
     pub fn ov_core_set_property(
         core: *const ov_core_t,
         device_name: *const ::std::os::raw::c_char,
-        ...
+        property_key: *const ::std::os::raw::c_char,
+        property_value: *const ::std::os::raw::c_char
     ) -> ov_status_e;
 }
 extern "C" {

--- a/crates/openvino-sys/src/generated/functions.rs
+++ b/crates/openvino-sys/src/generated/functions.rs
@@ -641,7 +641,7 @@ extern "C" {
     pub fn ov_compiled_model_set_property(
         compiled_model: *const ov_compiled_model_t,
         property_key: *const ::std::os::raw::c_char,
-        property_value: *const ::std::os::raw::c_char
+		property_value: *const ::std::os::raw::c_char
     ) -> ov_status_e;
 }
 extern "C" {
@@ -767,7 +767,7 @@ extern "C" {
         core: *const ov_core_t,
         device_name: *const ::std::os::raw::c_char,
         property_key: *const ::std::os::raw::c_char,
-        property_value: *const ::std::os::raw::c_char
+		property_value: *const ::std::os::raw::c_char
     ) -> ov_status_e;
 }
 extern "C" {

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -13,3 +13,4 @@ bindgen = "0.68.1"
 clap = { version = "4.4.4", features = ["derive"] }
 toml = "0.8.0"
 semver = "1.0"
+regex = "1.0.0"

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -13,4 +13,4 @@ bindgen = "0.68.1"
 clap = { version = "4.4.4", features = ["derive"] }
 toml = "0.8.0"
 semver = "1.0"
-regex = "1.0.0"
+regex = "1.10.4"

--- a/crates/xtask/src/codegen.rs
+++ b/crates/xtask/src/codegen.rs
@@ -41,7 +41,7 @@ impl CodegenCommand {
         let function_bindings = Self::generate_function_bindings(&header_file)?;
 
         // Runtime linking doesn't work yet with variadic args (...), so we need to convert them
-        // to a fixed pair of args (property_key, property_value)for a few select functions.
+        // to a fixed pair of args (property_key, property_value) for a few select functions.
         // This is a workaround until the runtime linking is updated to support variadic args.
         let functions_to_modify = vec!["ov_core_set_property", "ov_compiled_model_set_property"];
         let mut function_bindings_string = function_bindings.to_string();

--- a/crates/xtask/src/codegen.rs
+++ b/crates/xtask/src/codegen.rs
@@ -49,7 +49,7 @@ impl CodegenCommand {
             let re = Regex::new(&format!(r"(?s){}.*?\.\.\.", function)).unwrap();
             if re.is_match(&function_bindings_string) {
                 function_bindings_string = re.replace(&function_bindings_string, |caps: &regex::Captures| {
-                    caps[0].replace("...", "property_key: *const ::std::os::raw::c_char,\n\t\tproperty_value: *const ::std::os::raw::c_char")
+                    caps[0].replace("...", "property_key: *const ::std::os::raw::c_char,\n\tproperty_value: *const ::std::os::raw::c_char")
                 }).to_string();
             }
         }

--- a/crates/xtask/src/codegen.rs
+++ b/crates/xtask/src/codegen.rs
@@ -49,7 +49,7 @@ impl CodegenCommand {
             let re = Regex::new(&format!(r"(?s){}.*?\.\.\.", function)).unwrap();
             if re.is_match(&function_bindings_string) {
                 function_bindings_string = re.replace(&function_bindings_string, |caps: &regex::Captures| {
-                    caps[0].replace("...", "property_key: *const ::std::os::raw::c_char,\n\tproperty_value: *const ::std::os::raw::c_char")
+                    caps[0].replace("...", "property_key: *const ::std::os::raw::c_char,\n        property_value: *const ::std::os::raw::c_char")
                 }).to_string();
             }
         }


### PR DESCRIPTION
- Replaces variadic args `...` with `property_key: *const ::std::os::raw::c_char, property_value: *const ::std::os::raw::c_char` for 2 functions, `ov_compiled_model_set_property` and `ov_core_set_property`
- This is needed because variadic args do not yet work with runtime linking (link macro in `runtime.rs`)
- Other functions like `ov_core_compile_model` also have `...`, but these are not replaced as above since. The only place where they are replaced are functions which expect 1 or more pairs of property_key/property_value, but not in functions which expect 0 or more.
- The optional properties passed in `ov_core_compile_model` set properties just for that compiled model, while properties set in `ov_core_set_property` are for all models compiled with that core. Similarly, some subtle differences _seem_ to exist between properties set for `ov_compiled_model_set_property` and those in `ov_core_compile_model`. This is the reason why, for example, `ov_compiled_model_set_property` is not called from within `ov_core_compile_model` at this time.
- Regenerated function bindings with `cargo xtask codegen`