### PR TITLE
Switch to using a centrally-located workspace version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,21 @@
 [workspace]
-members = ["crates/openvino", "crates/openvino-sys", "crates/openvino-finder", "crates/xtask"]
+resolver = "2"
+members = [
+    "crates/openvino",
+    "crates/openvino-sys",
+    "crates/openvino-finder",
+    "crates/xtask",
+]
+
+[workspace.package]
+version = "0.6.0"
+authors = ["OpenVINO Project Developers"]
+edition = "2021"
+license = "Apache-2.0"
+readme = "README.md"
+repository = "https://github.com/intel/openvino-rs"
+
+[workspace.dependencies]
+openvino-sys = { path = "crates/openvino-sys", version = "=0.6.0" }
+openvino-finder = { path = "crates/openvino-finder", version = "=0.6.0" }
+env_logger = "0.10"

--- a/crates/openvino-finder/Cargo.toml
+++ b/crates/openvino-finder/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "openvino-finder"
-version = "0.6.0"
 description = "A helper crate for finding OpenVINO installations on a system."
-license = "Apache-2.0"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
 readme = "README.md"
-authors = ["OpenVINO Project Developers"]
 repository = "https://github.com/intel/openvino-rs"
 documentation = "https://docs.rs/openvino-finder"
 keywords = ["openvino", "machine-learning", "ml", "neural-network"]
 categories = ["development-tools"]
-edition = "2018"
 
 [dependencies]
 cfg-if = "1.0"
 log = "0.4"
 
 [dev-dependencies]
-env_logger = "0.10"
+env_logger = { workspace = true }

--- a/crates/openvino-sys/Cargo.toml
+++ b/crates/openvino-sys/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "openvino-sys"
-version = "0.6.0"
-license = "Apache-2.0"
 description = "Low-level bindings for OpenVINO (use the `openvino` crate for easier-to-use bindings)."
-readme = "README.md"
-authors = ["OpenVINO Project Developers"]
-repository = "https://github.com/intel/openvino-rs"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+readme.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/openvino-sys"
 keywords = ["openvino", "machine-learning", "ml", "neural-network"]
 categories = ["external-ffi-bindings", "science"]
-edition = "2018"
 include = [
     "/Cargo.toml",
     "/README.md",
@@ -22,16 +22,16 @@ include = [
     # - built from an OpenVINO installation when used as a dependency
     "/upstream/src/bindings/c/include",
 ]
-links = "inference_engine_c_api"
+links = "openvino_c_api"
 
 [dependencies]
 once_cell = { version = "1.18", optional = true }
 libloading = { version = "0.8", optional = true }
-openvino-finder = { version = "0.6.0", path = "../openvino-finder" }
+openvino-finder = { workspace = true }
 
 [build-dependencies]
-openvino-finder = { version = "0.6.0", path = "../openvino-finder" }
-env_logger = "0.10"
+openvino-finder = { workspace = true }
+env_logger = { workspace = true }
 
 [features]
 # Linking features: `build.rs` will default to dynamic linking if none is selected.

--- a/crates/openvino/Cargo.toml
+++ b/crates/openvino/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "openvino"
-version = "0.6.0"
-license = "Apache-2.0"
 description = "High-level bindings for OpenVINO."
-readme = "README.md"
-authors = ["OpenVINO Project Developers"]
-repository = "https://github.com/intel/openvino-rs"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+readme.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/openvino"
 keywords = ["openvino", "machine-learning", "ml", "neural-network"]
 categories = ["api-bindings", "science"]
-edition = "2018"
 exclude = ["/tests"]
 
 [dependencies]
-openvino-sys = { path = "../openvino-sys", version = "0.6.0" }
-openvino-finder = { path = "../openvino-finder", version = "0.6.0" }
+openvino-sys = { workspace = true }
+openvino-finder = { workspace = true }
 thiserror = "1.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This change only should update the location of the version string to a central place: the top-level `Cargo.toml`. This causes some churn in the `xtask` commands but the overall result should be the same.