### PR TITLE
Fix cstr macro leak

### DIFF
--- a/crates/openvino/src/core.rs
+++ b/crates/openvino/src/core.rs
@@ -37,9 +37,10 @@ impl Core {
 
     /// Construct a new OpenVINO [`Core`] with config specified in an xml file.
     pub fn new_with_config(xml_config_file: &str) -> std::result::Result<Core, SetupError> {
+        let xml_config_file = cstr!(xml_config_file);
         let mut ptr = std::ptr::null_mut();
         try_unsafe!(ov_core_create_with_config(
-            cstr!(xml_config_file.to_string()),
+            xml_config_file.as_ptr(),
             std::ptr::addr_of_mut!(ptr)
         ))?;
         Ok(Core { ptr })
@@ -56,7 +57,7 @@ impl Core {
         };
         try_unsafe!(ov_core_get_versions_by_device_name(
             self.ptr,
-            device_name,
+            device_name.as_ptr(),
             std::ptr::addr_of_mut!(ov_version_list)
         ))?;
 
@@ -110,7 +111,7 @@ impl Core {
         try_unsafe!(ov_core_get_property(
             self.ptr,
             EMPTY_C_STR.as_ptr(),
-            ov_prop_key,
+            ov_prop_key.as_ptr(),
             std::ptr::addr_of_mut!(ov_prop_value)
         ))?;
         let rust_prop = unsafe { CStr::from_ptr(ov_prop_value) }
@@ -127,8 +128,8 @@ impl Core {
         try_unsafe!(ov_core_set_property(
             self.ptr,
             EMPTY_C_STR.as_ptr(),
-            ov_prop_key,
-            ov_prop_value,
+            ov_prop_key.as_ptr(),
+            ov_prop_value.as_ptr(),
         ))?;
         Ok(())
     }
@@ -152,8 +153,8 @@ impl Core {
         let mut ov_prop_value = std::ptr::null_mut();
         try_unsafe!(ov_core_get_property(
             self.ptr,
-            ov_device_name,
-            ov_prop_key,
+            ov_device_name.as_ptr(),
+            ov_prop_key.as_ptr(),
             std::ptr::addr_of_mut!(ov_prop_value)
         ))?;
         let rust_prop = unsafe { CStr::from_ptr(ov_prop_value) }
@@ -175,9 +176,9 @@ impl Core {
         let ov_prop_value = cstr!(value);
         try_unsafe!(ov_core_set_property(
             self.ptr,
-            ov_device_name,
-            ov_prop_key,
-            ov_prop_value,
+            ov_device_name.as_ptr(),
+            ov_prop_key.as_ptr(),
+            ov_prop_value.as_ptr(),
         ))?;
         Ok(())
     }
@@ -197,11 +198,13 @@ impl Core {
     /// Read a Model from a pair of files: `model_path` points to an XML file containing the
     /// OpenVINO model IR and `weights_path` points to the binary weights file.
     pub fn read_model_from_file(&mut self, model_path: &str, weights_path: &str) -> Result<Model> {
+        let model_path = cstr!(model_path);
+        let weights_path = cstr!(weights_path);
         let mut ptr = std::ptr::null_mut();
         try_unsafe!(ov_core_read_model(
             self.ptr,
-            cstr!(model_path),
-            cstr!(weights_path),
+            model_path.as_ptr(),
+            weights_path.as_ptr(),
             std::ptr::addr_of_mut!(ptr)
         ))?;
         Ok(Model::from_ptr(ptr))

--- a/crates/openvino/src/layout.rs
+++ b/crates/openvino/src/layout.rs
@@ -16,9 +16,10 @@ impl Layout {
 
     /// Creates a new layout with the given description.
     pub fn new(layout_desc: &str) -> Result<Self> {
+        let layout_desc = cstr!(layout_desc);
         let mut layout = std::ptr::null_mut();
         try_unsafe!(ov_layout_create(
-            cstr!(layout_desc),
+            layout_desc.as_ptr(),
             std::ptr::addr_of_mut!(layout)
         ))?;
         Ok(Self { ptr: layout })

--- a/crates/openvino/src/model.rs
+++ b/crates/openvino/src/model.rs
@@ -150,7 +150,7 @@ impl CompiledModel {
         let mut port = std::ptr::null_mut();
         try_unsafe!(ov_compiled_model_input_by_name(
             self.ptr,
-            name,
+            name.as_ptr(),
             std::ptr::addr_of_mut!(port)
         ))?;
         Ok(Node::from_ptr(port))
@@ -190,7 +190,7 @@ impl CompiledModel {
         let mut port = std::ptr::null_mut();
         try_unsafe!(ov_compiled_model_output_by_name(
             self.ptr,
-            name,
+            name.as_ptr(),
             std::ptr::addr_of_mut!(port)
         ))?;
         Ok(Node::from_ptr(port))
@@ -212,7 +212,7 @@ impl CompiledModel {
         let mut ov_prop_value = std::ptr::null_mut();
         try_unsafe!(ov_compiled_model_get_property(
             self.ptr,
-            ov_prop_key,
+            ov_prop_key.as_ptr(),
             std::ptr::addr_of_mut!(ov_prop_value)
         ))?;
         let rust_prop = unsafe { CStr::from_ptr(ov_prop_value) }.to_string_lossy();
@@ -225,8 +225,8 @@ impl CompiledModel {
         let ov_prop_value = cstr!(value);
         try_unsafe!(ov_compiled_model_set_property(
             self.ptr,
-            ov_prop_key,
-            ov_prop_value,
+            ov_prop_key.as_ptr(),
+            ov_prop_value.as_ptr(),
         ))?;
         Ok(())
     }

--- a/crates/openvino/src/prepostprocess.rs
+++ b/crates/openvino/src/prepostprocess.rs
@@ -84,10 +84,11 @@ impl Pipeline {
 
     /// Retrieves the input information by name.
     pub fn get_input_info_by_name(&self, name: &str) -> Result<InputInfo> {
+        let name = cstr!(name);
         let mut ptr = std::ptr::null_mut();
         try_unsafe!(ov_preprocess_prepostprocessor_get_input_info_by_name(
             self.ptr,
-            cstr!(name),
+            name.as_ptr(),
             std::ptr::addr_of_mut!(ptr)
         ))?;
 
@@ -96,10 +97,11 @@ impl Pipeline {
 
     /// Retrieves the output information by name.
     pub fn get_output_info_by_name(&self, name: &str) -> Result<OutputInfo> {
+        let name = cstr!(name);
         let mut ptr = std::ptr::null_mut();
         try_unsafe!(ov_preprocess_prepostprocessor_get_output_info_by_name(
             self.ptr,
-            cstr!(name),
+            name.as_ptr(),
             std::ptr::addr_of_mut!(ptr)
         ))?;
         Ok(OutputInfo { ptr })

--- a/crates/openvino/src/request.rs
+++ b/crates/openvino/src/request.rs
@@ -27,9 +27,10 @@ impl InferRequest {
 
     /// Assign a [`Tensor`] to the input on the model.
     pub fn set_tensor(&mut self, name: &str, tensor: &Tensor) -> Result<()> {
+        let name = cstr!(name);
         try_unsafe!(ov_infer_request_set_tensor(
             self.ptr,
-            cstr!(name),
+            name.as_ptr(),
             tensor.as_ptr()
         ))?;
         Ok(())
@@ -37,10 +38,11 @@ impl InferRequest {
 
     /// Retrieve a [`Tensor`] from the output on the model.
     pub fn get_tensor(&self, name: &str) -> Result<Tensor> {
+        let name = cstr!(name);
         let mut tensor = std::ptr::null_mut();
         try_unsafe!(ov_infer_request_get_tensor(
             self.ptr,
-            cstr!(name),
+            name.as_ptr(),
             std::ptr::addr_of_mut!(tensor)
         ))?;
         Ok(Tensor::from_ptr(tensor))

--- a/crates/openvino/src/util.rs
+++ b/crates/openvino/src/util.rs
@@ -8,9 +8,7 @@ pub(crate) type Result<T> = std::result::Result<T, InferenceError>;
 #[macro_export]
 macro_rules! cstr {
     ($str: expr) => {
-        std::ffi::CString::new($str)
-            .expect("a valid C string")
-            .into_raw()
+        std::ffi::CString::new($str).expect("a valid C string")
     };
 }
 


### PR DESCRIPTION
The `cstr` macro uses `CString::into_raw()` to get the c-compatible string pointer.

However, per [Rust doc](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.into_raw), `into_raw` actually leaks the pointer if it isn't reclaimed and deallocated using `from_raw`.

This PR changes the macro and its usage to:

1. Create a CString
2. Keep it alive as we take its pointer (`as_ptr`)
3. Pass its `as_ptr` to the c functions