### PR TITLE
Fix core get/set properties

### DIFF
--- a/crates/openvino/src/core.rs
+++ b/crates/openvino/src/core.rs
@@ -16,8 +16,6 @@ use std::os::raw::c_char;
 use std::slice;
 use std::str::FromStr;
 
-const EMPTY_C_STR: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(b"\0") };
-
 /// See [`Core`](https://docs.openvino.ai/2024/api/c_cpp_api/group__ov__core__c__api.html).
 pub struct Core {
     ptr: *mut ov_core_t,
@@ -103,52 +101,10 @@ impl Core {
         Ok(devices)
     }
 
-    /// Gets properties related to this Core.
-    /// The method extracts information that can be set via the [set_property] method.
-    pub fn get_property(&self, key: PropertyKey) -> Result<String> {
-        let ov_prop_key = cstr!(key.as_ref());
-        let mut ov_prop_value = std::ptr::null_mut();
-        try_unsafe!(ov_core_get_property(
-            self.ptr,
-            EMPTY_C_STR.as_ptr(),
-            ov_prop_key.as_ptr(),
-            std::ptr::addr_of_mut!(ov_prop_value)
-        ))?;
-        let rust_prop = unsafe { CStr::from_ptr(ov_prop_value) }
-            .to_str()
-            .unwrap()
-            .to_owned();
-        Ok(rust_prop)
-    }
-
-    /// Sets a property for this Core instance.
-    pub fn set_property(&mut self, key: RwPropertyKey, value: &str) -> Result<()> {
-        let ov_prop_key = cstr!(key.as_ref());
-        let ov_prop_value = cstr!(value);
-        try_unsafe!(ov_core_set_property(
-            self.ptr,
-            EMPTY_C_STR.as_ptr(),
-            ov_prop_key.as_ptr(),
-            ov_prop_value.as_ptr(),
-        ))?;
-        Ok(())
-    }
-
-    /// Sets properties for this Core instance.
-    pub fn set_properties<'a>(
-        &mut self,
-        properties: impl IntoIterator<Item = (RwPropertyKey, &'a str)>,
-    ) -> Result<()> {
-        for (prop_key, prop_value) in properties {
-            self.set_property(prop_key, prop_value)?;
-        }
-        Ok(())
-    }
-
-    /// Gets properties related to device behaviour.
-    /// The method extracts information that can be set via the [set_device_property] method.
-    pub fn get_device_property(&self, device_name: &str, key: PropertyKey) -> Result<String> {
-        let ov_device_name = cstr!(device_name);
+    /// Gets properties related to device behaviour for this core.
+    /// The method extracts information that can be set via the [`set_property`] method.
+    pub fn get_property(&self, device_name: &DeviceType, key: PropertyKey) -> Result<String> {
+        let ov_device_name = cstr!(device_name.as_ref());
         let ov_prop_key = cstr!(key.as_ref());
         let mut ov_prop_value = std::ptr::null_mut();
         try_unsafe!(ov_core_get_property(
@@ -165,13 +121,13 @@ impl Core {
     }
 
     /// Sets a property for a device.
-    pub fn set_device_property(
+    pub fn set_property(
         &mut self,
-        device_name: &str,
+        device_name: &DeviceType,
         key: RwPropertyKey,
         value: &str,
     ) -> Result<()> {
-        let ov_device_name = cstr!(device_name);
+        let ov_device_name = cstr!(device_name.as_ref());
         let ov_prop_key = cstr!(key.as_ref());
         let ov_prop_value = cstr!(value);
         try_unsafe!(ov_core_set_property(
@@ -184,13 +140,13 @@ impl Core {
     }
 
     /// Sets properties for a device.
-    pub fn set_device_properties<'a>(
+    pub fn set_properties<'a>(
         &mut self,
-        device_name: &str,
+        device_name: DeviceType,
         properties: impl IntoIterator<Item = (RwPropertyKey, &'a str)>,
     ) -> Result<()> {
         for (prop_key, prop_value) in properties {
-            self.set_device_property(device_name, prop_key, prop_value)?;
+            self.set_property(&device_name, prop_key, prop_value)?;
         }
         Ok(())
     }
@@ -259,5 +215,13 @@ mod core_tests {
         let mut core = Core::new().unwrap();
         let model = core.read_model_from_buffer(model, None);
         assert!(model.is_ok());
+    }
+
+    #[test]
+    fn test_get_supported_properties() {
+        let core = Core::new().unwrap();
+        let supported_properties =
+            core.get_property(&DeviceType::CPU, PropertyKey::SupportedProperties);
+        assert!(supported_properties.is_ok());
     }
 }

--- a/crates/openvino/src/core.rs
+++ b/crates/openvino/src/core.rs
@@ -255,7 +255,6 @@ mod core_tests {
             HintSchedulingCoreType,
             HintInferencePrecision,
             HintNumRequests,
-            LogLevel,
             EnableProfiling,
             HintExecutionMode,
         ];

--- a/crates/openvino/src/core.rs
+++ b/crates/openvino/src/core.rs
@@ -259,11 +259,34 @@ mod core_tests {
             HintExecutionMode,
         ];
         for key in rw_keys {
-            let supported_properties = core.get_property(&DeviceType::CPU, &PropertyKey::Rw(&key));
+            let key_clone = key.clone();
+            let supported_properties = core.get_property(&DeviceType::CPU, &key.into());
             assert!(
                 supported_properties.is_ok(),
                 "Failed on rw key: {:?}",
-                &PropertyKey::Rw(&key)
+                &PropertyKey::Rw(key_clone)
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_core_properties_unsupported() {
+        let core = Core::new().unwrap();
+        let unsupported_keys = vec![
+            HintModelPriority,
+            DevicePriorities,
+            CacheMode,
+            ForceTbbTerminate,
+            EnableMmap,
+            AutoBatchTimeout,
+        ];
+        for key in unsupported_keys {
+            let key_clone = key.clone();
+            let supported_properties = core.get_property(&DeviceType::CPU, &key.into());
+            assert!(
+                supported_properties.is_err(),
+                "Failed on unsupported key: {:?}",
+                &key_clone
             );
         }
     }

--- a/crates/openvino/src/property.rs
+++ b/crates/openvino/src/property.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 /// See [`Property`](https://docs.openvino.ai/2024/api/c_cpp_api/group__ov__property__c__api.html).
 /// `PropertyKey` represents valid configuration properties for a [crate::Core] instance.
 #[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
-pub enum PropertyKey {
+pub enum PropertyKey<'a> {
     /// A string list of supported read-only properties.
     SupportedProperties,
     /// A list of available device IDs.
@@ -26,7 +26,7 @@ pub enum PropertyKey {
     /// Maximum batch size which does not cause performance degradation due to memory swap impact.
     MaxBatchSize,
     /// Read-write property key.
-    Rw(RwPropertyKey),
+    Rw(&'a RwPropertyKey),
     /// Arbitrary string property key.
     Other(Cow<'static, str>),
 }
@@ -89,7 +89,7 @@ pub enum RwPropertyKey {
     Other(Cow<'static, str>),
 }
 
-impl AsRef<str> for PropertyKey {
+impl AsRef<str> for PropertyKey<'_> {
     fn as_ref(&self) -> &str {
         match self {
             PropertyKey::SupportedProperties => "SUPPORTED_PROPERTIES",

--- a/crates/openvino/src/property.rs
+++ b/crates/openvino/src/property.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 /// See [`Property`](https://docs.openvino.ai/2024/api/c_cpp_api/group__ov__property__c__api.html).
 /// `PropertyKey` represents valid configuration properties for a [crate::Core] instance.
 #[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
-pub enum PropertyKey<'a> {
+pub enum PropertyKey {
     /// A string list of supported read-only properties.
     SupportedProperties,
     /// A list of available device IDs.
@@ -26,13 +26,13 @@ pub enum PropertyKey<'a> {
     /// Maximum batch size which does not cause performance degradation due to memory swap impact.
     MaxBatchSize,
     /// Read-write property key.
-    Rw(&'a RwPropertyKey),
+    Rw(RwPropertyKey),
     /// Arbitrary string property key.
     Other(Cow<'static, str>),
 }
 
 /// Read-write property keys.
-#[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Debug)]
+#[derive(Ord, PartialOrd, Eq, PartialEq, Hash, Debug, Clone)]
 pub enum RwPropertyKey {
     /// The directory which will be used to store any data cached by plugins.
     CacheDir,
@@ -89,7 +89,7 @@ pub enum RwPropertyKey {
     Other(Cow<'static, str>),
 }
 
-impl AsRef<str> for PropertyKey<'_> {
+impl AsRef<str> for PropertyKey {
     fn as_ref(&self) -> &str {
         match self {
             PropertyKey::SupportedProperties => "SUPPORTED_PROPERTIES",
@@ -132,5 +132,11 @@ impl AsRef<str> for RwPropertyKey {
             RwPropertyKey::AutoBatchTimeout => "AUTO_BATCH_TIMEOUT",
             RwPropertyKey::Other(s) => s,
         }
+    }
+}
+
+impl From<RwPropertyKey> for PropertyKey {
+    fn from(key: RwPropertyKey) -> Self {
+        PropertyKey::Rw(key)
     }
 }


### PR DESCRIPTION
- Resolves https://github.com/intel/openvino-rs/issues/122
- Removed functions which allowed get/set properties without device name. This use case is not documented in openvino docs, and the openvino c-api do not allow not passing device name, so this change adheres to that.
- Pass `property_key` as reference instead of value
- Added tests related to supported properties and RW properties for CPU
- I've opened an issue here https://github.com/openvinotoolkit/openvino/issues/24911 and will update with more tests based on the resolution there at a later point if need be (for example adding more tests checking unsupported cpu properties etc. It is undocumented right now, so haven't added those tests yet).