### PR TITLE
remove tensor new_from_host_ptr function

### DIFF
--- a/crates/openvino/src/prepostprocess.rs
+++ b/crates/openvino/src/prepostprocess.rs
@@ -12,7 +12,9 @@
 //! # ).expect("to read the model from file");
 //! # let data = fs::read("tests/fixtures/inception/tensor-1x3x299x299-f32.bgr").expect("to read the tensor from file");
 //! # let input_shape = Shape::new(&vec![1, 299, 299, 3]).expect("to create a new shape");
-//! # let tensor = Tensor::new_from_host_ptr(ElementType::F32, &input_shape, &data).expect("to create a new tensor from host pointer");
+//! # let mut tensor = Tensor::new(ElementType::F32, &input_shape).expect("to create a new tensor");
+//! # let buffer = tensor.buffer_mut().unwrap();
+//! # buffer.copy_from_slice(&data);
 //! // Insantiate a new core, read in a model, and set up a tensor with input data before performing pre/post processing
 //! // Pre-process the input by:
 //! // - converting NHWC to NCHW

--- a/crates/openvino/src/tensor.rs
+++ b/crates/openvino/src/tensor.rs
@@ -5,9 +5,9 @@ use crate::element_type::ElementType;
 use crate::shape::Shape;
 use crate::{drop_using_function, try_unsafe, util::Result};
 use openvino_sys::{
-    self, ov_shape_t, ov_tensor_create, ov_tensor_create_from_host_ptr, ov_tensor_data,
-    ov_tensor_free, ov_tensor_get_byte_size, ov_tensor_get_element_type, ov_tensor_get_shape,
-    ov_tensor_get_size, ov_tensor_set_shape, ov_tensor_t,
+    self, ov_shape_t, ov_tensor_create, ov_tensor_data, ov_tensor_free, ov_tensor_get_byte_size,
+    ov_tensor_get_element_type, ov_tensor_get_shape, ov_tensor_get_size, ov_tensor_set_shape,
+    ov_tensor_t,
 };
 
 /// See [`Tensor`](https://docs.openvino.ai/2023.3/api/c_cpp_api/group__ov__tensor__c__api.html).
@@ -32,30 +32,6 @@ impl Tensor {
     #[inline]
     pub(crate) fn from_ptr(ptr: *mut ov_tensor_t) -> Self {
         Self { ptr }
-    }
-
-    /// Create a new [`Tensor`] from a host pointer.
-    ///
-    /// # Arguments
-    ///
-    /// * `data_type` - The data type of the tensor.
-    /// * `shape` - The shape of the tensor.
-    /// * `data` - The data buffer.
-    ///
-    /// # Returns
-    ///
-    /// A new `Tensor` object.
-    pub fn new_from_host_ptr(data_type: ElementType, shape: &Shape, data: &[u8]) -> Result<Self> {
-        let mut tensor: *mut ov_tensor_t = std::ptr::null_mut();
-        let element_type: u32 = data_type as u32;
-        let buffer = data.as_ptr() as *mut std::os::raw::c_void;
-        try_unsafe!(ov_tensor_create_from_host_ptr(
-            element_type,
-            shape.as_c_struct(),
-            buffer,
-            std::ptr::addr_of_mut!(tensor)
-        ))?;
-        Ok(Self { ptr: tensor })
     }
 
     /// Get the pointer to the underlying OpenVINO tensor.

--- a/crates/openvino/tests/classify-alexnet.rs
+++ b/crates/openvino/tests/classify-alexnet.rs
@@ -27,7 +27,9 @@ fn classify_alexnet() -> anyhow::Result<()> {
     let data = fs::read(Fixture::tensor())?;
     let input_shape = Shape::new(&vec![1, 227, 227, 3])?;
     let element_type = ElementType::F32;
-    let tensor = Tensor::new_from_host_ptr(element_type, &input_shape, &data)?;
+    let mut tensor = Tensor::new(element_type, &input_shape)?;
+    let buffer = tensor.buffer_mut()?;
+    buffer.copy_from_slice(&data);
 
     // Pre-process the input by:
     // - converting NHWC to NCHW

--- a/crates/openvino/tests/classify-inception.rs
+++ b/crates/openvino/tests/classify-inception.rs
@@ -27,7 +27,9 @@ fn classify_inception() -> anyhow::Result<()> {
     let data = fs::read(Fixture::tensor())?;
     let input_shape = Shape::new(&vec![1, 299, 299, 3])?;
     let element_type = ElementType::F32;
-    let tensor = Tensor::new_from_host_ptr(element_type, &input_shape, &data)?;
+    let mut tensor = Tensor::new(element_type, &input_shape)?;
+    let buffer = tensor.buffer_mut()?;
+    buffer.copy_from_slice(&data);
 
     // Pre-process the input by:
     // - converting NHWC to NCHW

--- a/crates/openvino/tests/classify-mobilenet.rs
+++ b/crates/openvino/tests/classify-mobilenet.rs
@@ -27,7 +27,9 @@ fn classify_mobilenet() -> anyhow::Result<()> {
     let data = fs::read(Fixture::tensor())?;
     let input_shape = Shape::new(&vec![1, 224, 224, 3])?;
     let element_type = ElementType::F32;
-    let tensor = Tensor::new_from_host_ptr(element_type, &input_shape, &data)?;
+    let mut tensor = Tensor::new(element_type, &input_shape)?;
+    let buffer = tensor.buffer_mut()?;
+    buffer.copy_from_slice(&data);
 
     // Pre-process the input by:
     // - converting NHWC to NCHW


### PR DESCRIPTION
- Remove `new_from_host_ptr` function, since it was easy `data` field to go out of scope, causing a seg fault later in openvino.
- Now using `copy_from_buffer_slice` on the buffer of a newly created tensor