### PR TITLE
Replace `Tensor::buffer_mut`

### DIFF
--- a/crates/openvino/src/prepostprocess.rs
+++ b/crates/openvino/src/prepostprocess.rs
@@ -13,9 +13,9 @@
 //! # let data = fs::read("tests/fixtures/inception/tensor-1x3x299x299-f32.bgr").expect("to read the tensor from file");
 //! # let input_shape = Shape::new(&vec![1, 299, 299, 3]).expect("to create a new shape");
 //! # let mut tensor = Tensor::new(ElementType::F32, &input_shape).expect("to create a new tensor");
-//! # let buffer = tensor.buffer_mut().unwrap();
+//! # let buffer = tensor.get_raw_data_mut().unwrap();
 //! # buffer.copy_from_slice(&data);
-//! // Insantiate a new core, read in a model, and set up a tensor with input data before performing pre/post processing
+//! // Instantiate a new core, read in a model, and set up a tensor with input data before performing pre/post processing
 //! // Pre-process the input by:
 //! // - converting NHWC to NCHW
 //! // - resizing the input image

--- a/crates/openvino/tests/classify-alexnet.rs
+++ b/crates/openvino/tests/classify-alexnet.rs
@@ -28,7 +28,7 @@ fn classify_alexnet() -> anyhow::Result<()> {
     let input_shape = Shape::new(&vec![1, 227, 227, 3])?;
     let element_type = ElementType::F32;
     let mut tensor = Tensor::new(element_type, &input_shape)?;
-    let buffer = tensor.buffer_mut()?;
+    let buffer = tensor.get_raw_data_mut()?;
     buffer.copy_from_slice(&data);
 
     // Pre-process the input by:

--- a/crates/openvino/tests/classify-inception.rs
+++ b/crates/openvino/tests/classify-inception.rs
@@ -28,7 +28,7 @@ fn classify_inception() -> anyhow::Result<()> {
     let input_shape = Shape::new(&vec![1, 299, 299, 3])?;
     let element_type = ElementType::F32;
     let mut tensor = Tensor::new(element_type, &input_shape)?;
-    let buffer = tensor.buffer_mut()?;
+    let buffer = tensor.get_raw_data_mut()?;
     buffer.copy_from_slice(&data);
 
     // Pre-process the input by:

--- a/crates/openvino/tests/classify-mobilenet.rs
+++ b/crates/openvino/tests/classify-mobilenet.rs
@@ -28,7 +28,7 @@ fn classify_mobilenet() -> anyhow::Result<()> {
     let input_shape = Shape::new(&vec![1, 224, 224, 3])?;
     let element_type = ElementType::F32;
     let mut tensor = Tensor::new(element_type, &input_shape)?;
-    let buffer = tensor.buffer_mut()?;
+    let buffer = tensor.get_raw_data_mut()?;
     buffer.copy_from_slice(&data);
 
     // Pre-process the input by:


### PR DESCRIPTION
This refactors the data accessor functions in `Tensor` to be more consistent with conventions elsewhere (e.g., `get_`). It also checks a bit more robustly whether the underlying pointer can in fact be casted to the type we expect.