### PR TITLE
doc: add an in-memory tensor data example

### DIFF
--- a/crates/openvino/src/core.rs
+++ b/crates/openvino/src/core.rs
@@ -112,7 +112,7 @@ impl Core {
 
     /// Gets properties related to device behavior.
     ///
-    /// The method extracts information that can be set via the [`set_property`] method.
+    /// The method extracts information that can be set via the [`Core::set_property`] method.
     ///
     /// # Panics
     ///

--- a/crates/openvino/src/tensor.rs
+++ b/crates/openvino/src/tensor.rs
@@ -17,6 +17,7 @@ use openvino_sys::{
 /// ```rust
 /// # use openvino::{Shape, Tensor, ElementType};
 /// # fn main() -> anyhow::Result<()> {
+/// # openvino_sys::library::load().unwrap();
 /// let data = [1u8; 1000];
 /// let shape = Shape::new(&[10, 10, 10])?;
 /// let mut tensor = Tensor::new(ElementType::U8, &shape)?;

--- a/crates/openvino/src/tensor.rs
+++ b/crates/openvino/src/tensor.rs
@@ -11,6 +11,25 @@ use openvino_sys::{
 };
 
 /// See [`Tensor`](https://docs.openvino.ai/2023.3/api/c_cpp_api/group__ov__tensor__c__api.html).
+///
+/// To create a tensor from in-memory data, construct it and then fill it:
+///
+/// ```rust
+/// # use openvino::{Shape, Tensor, ElementType};
+/// # fn main() -> anyhow::Result<()> {
+/// let data = [1u8; 1000];
+/// let shape = Shape::new(&[10, 10, 10])?;
+/// let mut tensor = Tensor::new(ElementType::U8, &shape)?;
+/// tensor.get_raw_data_mut()?.copy_from_slice(&data);
+/// # Ok(())
+/// # }
+/// ```
+///
+/// This approach currently results in a copy, which is sub-optimal. It is safe, however; passing a
+/// slice to OpenVINO is unsafe unless additional lifetime constraints are added (to improve this in
+/// the future, see the context in [#125]).
+///
+/// [#125]: https://github.com/intel/openvino-rs/pull/125
 pub struct Tensor {
     ptr: *mut ov_tensor_t,
 }

--- a/crates/openvino/src/util.rs
+++ b/crates/openvino/src/util.rs
@@ -27,7 +27,8 @@ macro_rules! drop_using_function {
     ($ty: ty, $free_fn: expr) => {
         impl Drop for $ty {
             fn drop(&mut self) {
-                unsafe { $free_fn(self.ptr.cast()) }
+                let free = $free_fn;
+                unsafe { free(self.ptr.cast()) }
             }
         }
     };


### PR DESCRIPTION
This should make it more obvious how to construct and then fill a tensor from in-memory data. Still unresolved: it would be nice to have all the lifetimes wired up so that we can avoid a copy over to the C++ side, but that is left open for now.