### PR TITLE
ci: add initial code scan configuration

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -1,0 +1,48 @@
+# Scan the code in this repository; publish results to
+# https://github.com/intel/openvino-rs/security/code-scanning.
+
+name: Code Scan
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+  schedule:
+    - cron: "3 2 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze (Rust)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Install clippy
+        run: rustup component add clippy
+
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@3a99ae3c155195e5518c9ff954bee1b90f98b82c # v1.10.6
+
+      - name: Install dependencies
+        run: cargo binstall --no-confirm clippy-sarif sarif-fmt
+
+      - name: Run clippy
+        run: |
+          cargo clippy --features openvino-sys/runtime-linking --message-format=json > clippy.json
+          clippy-sarif --input clippy.json --output clippy.sarif
+          sarif-fmt --input clippy.sarif
+        continue-on-error: true
+
+      - name: Upload analysis
+        uses: github/codeql-action/upload-sarif@5618c9fc1e675841ca52c1c6b1304f5255a905a0 # v2.19.0
+        with:
+          sarif_file: clippy.sarif
+          wait-for-processing: true


### PR DESCRIPTION
This will integrate `clippy` with GitHub's code scanning feature.