### PR TITLE
Remove `thiserror` dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -391,7 +391,6 @@ dependencies = [
  "float-cmp",
  "openvino-finder",
  "openvino-sys",
- "thiserror",
 ]
 
 [[package]]
@@ -560,26 +559,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
 dependencies = [
  "winapi-util",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
-dependencies = [
- "thiserror-impl",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.48"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/crates/openvino/Cargo.toml
+++ b/crates/openvino/Cargo.toml
@@ -15,7 +15,6 @@ exclude = ["/tests"]
 [dependencies]
 openvino-sys = { workspace = true }
 openvino-finder = { workspace = true }
-thiserror = "1.0"
 
 [dev-dependencies]
 float-cmp = "0.9"

--- a/crates/openvino/src/request.rs
+++ b/crates/openvino/src/request.rs
@@ -121,12 +121,12 @@ impl InferRequest {
         try_unsafe!(ov_infer_request_cancel(self.ptr))
     }
 
-    /// Execute the inference request asyncroneously.
+    /// Execute the inference request asynchronously.
     pub fn infer_async(&mut self) -> Result<()> {
         try_unsafe!(ov_infer_request_start_async(self.ptr))
     }
 
-    /// Wait for the result of the inference asyncroneous request.
+    /// Wait for the result of the inference asynchronous request.
     pub fn wait(&mut self, timeout: i64) -> Result<()> {
         try_unsafe!(ov_infer_request_wait_for(self.ptr, timeout))
     }


### PR DESCRIPTION
The `thiserror` crate served well in the early days of these bindings as a helpful tool to quickly stand up error `enum`s. I noticed that other errors had switched to writing out the full error implementation so this change finishes that process, removing the `thiserror` dependency.