### PR TITLE
Add `xtask` to update upstream submodule

### DIFF
--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -6,6 +6,7 @@
 mod bump;
 mod codegen;
 mod publish;
+mod update;
 mod util;
 
 use anyhow::Result;
@@ -13,6 +14,7 @@ use bump::BumpCommand;
 use clap::{Parser, Subcommand};
 use codegen::CodegenCommand;
 use publish::PublishCommand;
+use update::UpdateCommand;
 
 fn main() -> Result<()> {
     let cli = Cli::parse();
@@ -29,6 +31,8 @@ struct Cli {
 
 #[derive(Debug, Subcommand)]
 enum XtaskCommand {
+    /// Update the upstream OpenVINO Git submodule.
+    Update(UpdateCommand),
     /// Generate the Rust bindings for OpenVINO to use in the openvino-sys crate.
     Codegen(CodegenCommand),
     /// Increment the version of each of the publishable crates.
@@ -40,6 +44,7 @@ enum XtaskCommand {
 impl XtaskCommand {
     fn execute(&self) -> Result<()> {
         match self {
+            Self::Update(update) => update.execute(),
             Self::Codegen(codegen) => codegen.execute(),
             Self::Bump(bump) => bump.execute(),
             Self::Publish(publish) => publish.execute(),

--- a/crates/xtask/src/update.rs
+++ b/crates/xtask/src/update.rs
@@ -1,0 +1,23 @@
+use crate::util::{exec, path_to_crates};
+use anyhow::Result;
+use clap::Args;
+use std::process::Command;
+
+#[derive(Debug, Args)]
+pub struct UpdateCommand {
+    /// The upstream tag to update to; see https://github.com/openvinotoolkit/openvino/releases.
+    #[arg(name = "TAG")]
+    tag: String,
+}
+
+impl UpdateCommand {
+    /// Retrieve the requested tag and checkout the upstream submodule using `git`.
+    pub fn execute(&self) -> Result<()> {
+        let submodule = path_to_crates()?.join("openvino-sys/upstream");
+        let submodule = submodule.to_string_lossy();
+        exec(Command::new("git").args(["-C", &submodule, "fetch", "origin", "tag", &self.tag]))?;
+        exec(Command::new("git").args(["-C", &submodule, "checkout", &self.tag]))?;
+        println!("> to use the updated headers, run `cargo xtask codegen`");
+        Ok(())
+    }
+}

--- a/crates/xtask/src/update.rs
+++ b/crates/xtask/src/update.rs
@@ -5,7 +5,7 @@ use std::process::Command;
 
 #[derive(Debug, Args)]
 pub struct UpdateCommand {
-    /// The upstream tag to update to; see https://github.com/openvinotoolkit/openvino/releases.
+    /// The upstream tag to update to; see <https://github.com/openvinotoolkit/openvino/releases>.
     #[arg(name = "TAG")]
     tag: String,
 }

--- a/crates/xtask/src/util.rs
+++ b/crates/xtask/src/util.rs
@@ -6,6 +6,7 @@ use toml::Value;
 
 /// Convenience wrapper for executing commands.
 pub fn exec(command: &mut Command) -> Result<()> {
+    eprintln!("+ executing: {:?}", &command);
     let status = command.status()?;
     if status.success() {
         Ok(())


### PR DESCRIPTION
Every so often the upstream OpenVINO repository releases a new version. This new task, `cargo xtask update <tag>`, will run some Git commands to update Git submodule tracked by this repository. Since each release may slightly tweak the header files, this new task is expected to be used immediately prior to `cargo xtask codegen; cargo test`.