### PR TITLE
Fine-tune version check for ignored tests

### DIFF
--- a/crates/openvino/tests/util.rs
+++ b/crates/openvino/tests/util.rs
@@ -90,5 +90,5 @@ pub fn is_version_pre_2024_2() -> bool {
     let mut parts = version.parts();
     let year: usize = parts.next().unwrap().parse().unwrap();
     let minor: usize = parts.next().unwrap().parse().unwrap();
-    year <= 2024 || (year == 2024 && minor < 2)
+    year < 2024 || (year == 2024 && minor < 2)
 }


### PR DESCRIPTION
@rahulchaphalkar pointed out that the first part of this check should filter out pre-2024 releases; fixes an issue in #144.