### PR TITLE
Allow a pedantic doc comment lint

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
     - name: Enable long paths
       run: git config --global core.longpaths true
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: true
     - uses: actions/cache@v4.0.2
@@ -72,7 +72,7 @@ jobs:
     name: Check code format
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: true
     - run: rustup component add rustfmt
@@ -86,14 +86,14 @@ jobs:
     name: Check Rust dependencies
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
     - uses: EmbarkStudios/cargo-deny-action@v1
 
   docs:
     name: Check documentation
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: true
     - name: Build documentation
@@ -109,7 +109,7 @@ jobs:
       run:
         working-directory: crates/openvino-tensor-converter
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: true
     - name: Install OpenCV
@@ -125,7 +125,7 @@ jobs:
     name: Generate openvino-sys bindings
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: recursive
     - name: Generate bindings

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         submodules: true
-    - uses: actions/cache@v4.0.2
+    - uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         key: openvino-test-fixtures
         path: |

--- a/crates/openvino-sys/src/lib.rs
+++ b/crates/openvino-sys/src/lib.rs
@@ -30,8 +30,11 @@
 #![deny(clippy::all)]
 #![warn(clippy::pedantic)]
 #![warn(clippy::cargo)]
-#![allow(clippy::must_use_candidate)]
-#![allow(clippy::wildcard_imports)]
+#![allow(
+    clippy::must_use_candidate,
+    clippy::suspicious_doc_comments,
+    clippy::wildcard_imports
+)]
 
 mod linking;
 


### PR DESCRIPTION
This enables `clippy::suspicious_doc_comments` that is a bit too strict for the generated code.