### PR TITLE
Make code scan more robust

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -36,10 +36,9 @@ jobs:
 
       - name: Run clippy
         run: |
-          cargo clippy --features openvino-sys/runtime-linking --message-format=json > clippy.json
+          cargo clippy --features openvino-sys/runtime-linking --message-format=json > clippy.json || true
           clippy-sarif --input clippy.json --output clippy.sarif
           sarif-fmt --input clippy.sarif
-        continue-on-error: true
 
       - name: Upload analysis
         uses: github/codeql-action/upload-sarif@5618c9fc1e675841ca52c1c6b1304f5255a905a0 # v2.19.0


### PR DESCRIPTION
This CI check fails if `cargo clippy` fails, which is unfortunate since we really want the output of `cargo clippy`, errors and all, available to the CodeQL action. This change attempts to remedy that by ignoring any error code returned by `cargo clippy` (and only `cargo clippy`; we expect the other steps to succeed.