### PR TITLE
ci: automatically run every two weeks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,13 @@ name: CI
 permissions: read-all
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    cron:  '30 7 2,16 * *' # Every 2nd and 16th of the month at 07:30 UTC
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
The purpose of this is to more quickly identify CI bit rot (e.g., outdated packages, runner images).  Any failures should result in notifications, prompting quicker resolution.

Also, this includes a manual trigger for starting CI runs from https://github.com/intel/openvino-rs/actions/workflows/main.yml.