### PR TITLE
Replace `once_cell` with the now-standard `LazyLock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -327,12 +327,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-
-[[package]]
 name = "openvino"
 version = "0.8.0"
 dependencies = [
@@ -357,7 +351,6 @@ version = "0.8.0"
 dependencies = [
  "env_logger",
  "libloading 0.8.0",
- "once_cell",
  "openvino-finder",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ authors = ["OpenVINO Project Developers"]
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/intel/openvino-rs"
+# This is only necessary for use of `LazyLock` in `openvino-sys`.
+rust-version = "1.80.0"
 
 [workspace.dependencies]
 openvino-sys = { path = "crates/openvino-sys", version = "=0.8.0" }

--- a/crates/openvino-sys/Cargo.toml
+++ b/crates/openvino-sys/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme = "README.md"
 documentation = "https://docs.rs/openvino-sys"
 keywords = ["openvino", "machine-learning", "ml", "neural-network"]
@@ -25,7 +26,6 @@ include = [
 links = "openvino_c_api"
 
 [dependencies]
-once_cell = { version = "1.20", optional = true }
 libloading = { version = "0.8", optional = true }
 openvino-finder = { workspace = true }
 
@@ -38,7 +38,7 @@ env_logger = { workspace = true }
 # - Will find and bind to an OpenVINO shared library at compile time.
 dynamic-linking = []
 # - Will bind to an OpenVINO shared library at runtime using `load`.
-runtime-linking = ["libloading", "once_cell"]
+runtime-linking = ["libloading"]
 
 [package.metadata.docs.rs]
 features = ["runtime-linking"]

--- a/crates/openvino-sys/src/linking/runtime.rs
+++ b/crates/openvino-sys/src/linking/runtime.rs
@@ -10,11 +10,9 @@ macro_rules! link {
             }
         )+
     ) => (
-        use once_cell::sync::Lazy;
         use libloading;
         use std::path::PathBuf;
-        use std::sync::Arc;
-        use std::sync::RwLock;
+        use std::sync::{Arc, LazyLock, RwLock};
 
         // Wrap the loaded functions.
         #[derive(Debug)]
@@ -34,7 +32,7 @@ macro_rules! link {
         }
 
         // `LIBRARY` holds the shared library reference.
-        static LIBRARY: Lazy<RwLock<Option<Arc<SharedLibrary>>>> = Lazy::new(|| RwLock::new(None));
+        static LIBRARY: LazyLock<RwLock<Option<Arc<SharedLibrary>>>> = LazyLock::new(|| RwLock::new(None));
 
         // Helper function for accessing the thread-local version of the library.
         fn with_library<T, F>(f: F) -> Option<T>

--- a/crates/openvino/Cargo.toml
+++ b/crates/openvino/Cargo.toml
@@ -6,6 +6,7 @@ authors.workspace = true
 license.workspace = true
 edition.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 readme = "README.md"
 documentation = "https://docs.rs/openvino"
 keywords = ["openvino", "machine-learning", "ml", "neural-network"]


### PR DESCRIPTION
As pointed out by code scan [#88], `std::sync::LazyLock` is the standard way to initialize static values. `LazyLock` has been available since Rust [v1.80.0]. This change switches to `LazyLock` and removes the now-unnecessary `once_cell` crate. It also throws a few `rust-version` annotations in to remind users what version of Rust to use.

[#88]: https://github.com/intel/openvino-rs/security/code-scanning/88
[v1.80.0]: https://releases.rs/docs/1.80.0