### PR TITLE
Specify the ABI of each linked-to OpenVINO function

### DIFF
--- a/crates/openvino-sys/src/linking/runtime.rs
+++ b/crates/openvino-sys/src/linking/runtime.rs
@@ -49,7 +49,7 @@ macro_rules! link {
         pub(crate) struct Functions {
             $(
                 $(#[doc=$doc])* $(#[cfg($cfg)])*
-                pub $name: Option<unsafe extern fn($($pname: $pty), *) $(-> $ret)*>,
+                pub $name: Option<unsafe extern "C" fn($($pname: $pty), *) $(-> $ret)*>,
             )+
         }
 


### PR DESCRIPTION
This was pointed out by code scan [#87]: clippy now says that "extern declarations without an explicit ABI are deprecated." This change adds the `"C"` ABI definition, matching the `extern "C"` we use above when we declare each function.

[#87]: https://github.com/intel/openvino-rs/security/code-scanning/87