### PR TITLE
Upgrade bindings to v2025.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,14 +24,14 @@ jobs:
         # found ("dyld: Library not loaded; '@rpath/libopenvino.2310.dylib'"). See
         # https://github.com/abrown/openvino-rs/actions/runs/6423141936/job/17441022932#step:7:154
         os: [ubuntu-22.04, ubuntu-24.04, windows-latest]
-        version: [2024.4.0, 2024.5.0, 2024.6.0]
+        version: [2025.1.0]
         apt: [false]
         # We also spot-check that things work when installing from APT by adding to the matrix: see
         # https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations
         # APT install and check latest supported version.
         include:
           - os: ubuntu-24.04
-            version: 2024.4.0
+            version: 2025.1.0
             apt: true
     env:
       RUST_LOG: debug

--- a/crates/openvino-sys/src/generated/functions.rs
+++ b/crates/openvino-sys/src/generated/functions.rs
@@ -1109,5 +1109,17 @@ extern "C" {
         model: *mut *mut ov_model_t,
     ) -> ov_status_e;
 }
+extern "C" {
+    #[doc = " @brief Add pad preprocess operation. Extends an input tensor on edges with constants.\n\n @param preprocess_input_process_steps  A pointer to the ov_preprocess_preprocess_steps_t.\n @param pads_begin                      Number of padding elements to add at the beginning of each axis.\n @param pads_begin_size                 Pads begin size (number of axes).\n @param pads_end                        Number of padding elements to add at the end of each axis.\n @param pads_end_size                   Pads end size (number of axes).\n @param value                           Value to be populated in the padded area (mode=CONSTANT)\n @param mode                            Padding mode."]
+    pub fn ov_preprocess_preprocess_steps_pad(
+        preprocess_input_process_steps: *const ov_preprocess_preprocess_steps_t,
+        pads_begin: *const ::std::os::raw::c_int,
+        pads_begin_size: usize,
+        pads_end: *const ::std::os::raw::c_int,
+        pads_end_size: usize,
+        value: f32,
+        mode: ov_padding_mode_e,
+    ) -> ov_status_e;
+}
 
 }

--- a/crates/openvino-sys/src/generated/types.rs
+++ b/crates/openvino-sys/src/generated/types.rs
@@ -41,64 +41,65 @@ pub enum ov_status_e {
     #[doc = "!< UNKNOW_EXCEPTION"]
     UNKNOW_EXCEPTION = -17,
 }
+impl ov_element_type_e {
+    pub const DYNAMIC: ov_element_type_e = ov_element_type_e::UNDEFINED;
+}
 #[repr(u32)]
 #[doc = " @enum ov_element_type_e\n @ingroup ov_base_c_api\n @brief This enum contains codes for element type, which is aligned with ov::element::Type_t in\n src/core/include/openvino/core/type/element_type.hpp"]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
 pub enum ov_element_type_e {
     #[doc = "!< Undefined element type"]
     UNDEFINED = 0,
-    #[doc = "!< Dynamic element type"]
-    DYNAMIC = 1,
     #[doc = "!< boolean element type"]
-    OV_BOOLEAN = 2,
+    OV_BOOLEAN = 1,
     #[doc = "!< bf16 element type"]
-    BF16 = 3,
+    BF16 = 2,
     #[doc = "!< f16 element type"]
-    F16 = 4,
+    F16 = 3,
     #[doc = "!< f32 element type"]
-    F32 = 5,
+    F32 = 4,
     #[doc = "!< f64 element type"]
-    F64 = 6,
+    F64 = 5,
     #[doc = "!< i4 element type"]
-    I4 = 7,
+    I4 = 6,
     #[doc = "!< i8 element type"]
-    I8 = 8,
+    I8 = 7,
     #[doc = "!< i16 element type"]
-    I16 = 9,
+    I16 = 8,
     #[doc = "!< i32 element type"]
-    I32 = 10,
+    I32 = 9,
     #[doc = "!< i64 element type"]
-    I64 = 11,
+    I64 = 10,
     #[doc = "!< binary element type"]
-    U1 = 12,
+    U1 = 11,
     #[doc = "!< u2 element type"]
-    U2 = 13,
+    U2 = 12,
     #[doc = "!< u3 element type"]
-    U3 = 14,
+    U3 = 13,
     #[doc = "!< u4 element type"]
-    U4 = 15,
+    U4 = 14,
     #[doc = "!< u6 element type"]
-    U6 = 16,
+    U6 = 15,
     #[doc = "!< u8 element type"]
-    U8 = 17,
+    U8 = 16,
     #[doc = "!< u16 element type"]
-    U16 = 18,
+    U16 = 17,
     #[doc = "!< u32 element type"]
-    U32 = 19,
+    U32 = 18,
     #[doc = "!< u64 element type"]
-    U64 = 20,
+    U64 = 19,
     #[doc = "!< nf4 element type"]
-    NF4 = 21,
+    NF4 = 20,
     #[doc = "!< f8e4m3 element type"]
-    F8E4M3 = 22,
+    F8E4M3 = 21,
     #[doc = "!< f8e5m2 element type"]
-    F8E5M3 = 23,
+    F8E5M3 = 22,
     #[doc = "!< string element type"]
-    STRING = 24,
+    STRING = 23,
     #[doc = "!< f4e2m1 element type"]
-    F4E2M1 = 25,
+    F4E2M1 = 24,
     #[doc = "!< f8e8m0 element type"]
-    F8E8M0 = 26,
+    F8E8M0 = 25,
 }
 #[doc = " @brief encryption_func is a function pointer that encrypt or decrypt the input memory, example of this function is\n codec(const char* input, const size_t in_size, const char* output, size_t* out_size)\n This function needs to be called twice,\n the first call to obtain out_size (the size of output buffer), the second call to obtain output buffer.\n The first call output is nullptr, before the second call, the caller needs to apply for output\n memory based on the out_size returned by the first call.\n the memory of parameter output is allocated and released by the caller.\n @param input The pointer to the input buffer.\n @param in_size The size of input.\n @param output The pointer to the encrypted/decrypted buffer.\n @param out_size The size of output."]
 pub type encryption_func = ::std::option::Option<
@@ -485,4 +486,17 @@ pub enum ov_preprocess_resize_algorithm_e {
     RESIZE_CUBIC = 1,
     #[doc = "!< nearest algorithm"]
     RESIZE_NEAREST = 2,
+}
+#[repr(u32)]
+#[doc = " @enum ov_padding_mode_e\n @ingroup ov_prepostprocess_c_api\n @brief This enum contains enumeration for  padding mode."]
+#[derive(Debug, Copy, Clone, Hash, PartialEq, Eq)]
+pub enum ov_padding_mode_e {
+    #[doc = "!< Pads with given constant value."]
+    CONSTANT = 0,
+    #[doc = "!< Pads with tensor edge values."]
+    EDGE = 1,
+    #[doc = "!< Pads with reflection of tensor data along axis. Values on the edges are not duplicated."]
+    REFLECT = 2,
+    #[doc = "!<  Pads similar like `REFLECT` but values on the edges are duplicated."]
+    SYMMETRIC = 3,
 }

--- a/crates/openvino/src/core.rs
+++ b/crates/openvino/src/core.rs
@@ -261,7 +261,6 @@ mod core_tests {
         let rw_keys = vec![
             CacheDir,
             NumStreams,
-            Affinity,
             InferenceNumThreads,
             HintEnableCpuPinning,
             HintEnableHyperThreading,

--- a/crates/openvino/src/element_type.rs
+++ b/crates/openvino/src/element_type.rs
@@ -6,8 +6,6 @@ use std::fmt;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 #[repr(u32)]
 pub enum ElementType {
-    /// An undefined element type.
-    Undefined,
     /// A dynamic element type.
     Dynamic,
     /// A boolean element type.
@@ -65,7 +63,6 @@ pub enum ElementType {
 impl From<ov_element_type_e> for ElementType {
     fn from(ty: ov_element_type_e) -> Self {
         match ty {
-            ov_element_type_e::UNDEFINED => Self::Undefined,
             ov_element_type_e::DYNAMIC => Self::Dynamic,
             ov_element_type_e::OV_BOOLEAN => Self::Boolean,
             ov_element_type_e::BF16 => Self::Bf16,
@@ -99,7 +96,6 @@ impl From<ov_element_type_e> for ElementType {
 impl From<ElementType> for ov_element_type_e {
     fn from(ty: ElementType) -> ov_element_type_e {
         match ty {
-            ElementType::Undefined => ov_element_type_e::UNDEFINED,
             ElementType::Dynamic => ov_element_type_e::DYNAMIC,
             ElementType::Boolean => ov_element_type_e::OV_BOOLEAN,
             ElementType::Bf16 => ov_element_type_e::BF16,
@@ -133,7 +129,6 @@ impl From<ElementType> for ov_element_type_e {
 impl fmt::Display for ElementType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::Undefined => write!(f, "Undefined"),
             Self::Dynamic => write!(f, "Dynamic"),
             Self::Boolean => write!(f, "Boolean"),
             Self::Bf16 => write!(f, "BF16"),

--- a/crates/openvino/src/property.rs
+++ b/crates/openvino/src/property.rs
@@ -43,8 +43,6 @@ pub enum RwPropertyKey {
     CacheMode,
     /// The number of executor logical partitions.
     NumStreams,
-    /// CPU affinity per thread.
-    Affinity,
     /// The maximum number of threads that can be used for inference tasks.
     InferenceNumThreads,
     /// High-level OpenVINO hint for using CPU pinning to bind CPU threads to processors during inference.
@@ -114,7 +112,6 @@ impl AsRef<str> for RwPropertyKey {
             RwPropertyKey::CacheDir => "CACHE_DIR",
             RwPropertyKey::CacheMode => "CACHE_MODE",
             RwPropertyKey::NumStreams => "NUM_STREAMS",
-            RwPropertyKey::Affinity => "AFFINITY",
             RwPropertyKey::InferenceNumThreads => "INFERENCE_NUM_THREADS",
             RwPropertyKey::HintEnableCpuPinning => "ENABLE_CPU_PINNING",
             RwPropertyKey::HintEnableHyperThreading => "ENABLE_HYPER_THREADING",


### PR DESCRIPTION
This takes some of the work by @Rickvanderveen in #159 (thanks!) and makes the crate compatible with OpenVINO v2025.1.0 and above. I've documented the breaking ABI change from upstream in https://github.com/intel/openvino-rs/issues/167 and will follow this up with a fix to only allow this code to work with versions 2025.1.0 and above.