### PR TITLE
[openvino-finder] Update search paths to include all supported arch

### DIFF
--- a/crates/openvino-finder/src/lib.rs
+++ b/crates/openvino-finder/src/lib.rs
@@ -241,17 +241,35 @@ cfg_if! {
 const KNOWN_INSTALLATION_SUBDIRECTORIES: &[&str] = &[
     "runtime/lib/intel64/Release",
     "runtime/lib/intel64",
-    "runtime/3rdparty/tbb/lib",
+    "runtime/lib/arm64/Release",
+    "runtime/lib/arm64",
+    "runtime/lib/aarch64/Release",
+    "runtime/lib/aarch64",
+    "runtime/lib/armv7l",
+    "runtime/lib/armv7l/Release",
     "runtime/bin/intel64/Release",
     "runtime/bin/intel64",
+    "runtime/bin/arm64/Release",
+    "runtime/bin/arm64",
     "runtime/3rdparty/tbb/bin",
+    "runtime/3rdparty/tbb/lib",
 ];
 
 const KNOWN_BUILD_SUBDIRECTORIES: &[&str] = &[
     "bin/intel64/Debug/lib",
     "bin/intel64/Debug",
     "bin/intel64/Release/lib",
+    "bin/arm64/Debug/lib",
+    "bin/arm64/Debug",
+    "bin/arm64/Release/lib",
+    "bin/aarch64/Debug/lib",
+    "bin/aarch64/Debug",
+    "bin/aarch64/Release/lib",
+    "bin/armv7l/Debug/lib",
+    "bin/armv7l/Debug",
+    "bin/armv7l/Release/lib",
     "temp/tbb/lib",
+    "temp/tbb/bin",
 ];
 
 /// Find the path to the `plugins.xml` configuration file.


### PR DESCRIPTION
This PR updates the list of paths that `openvino-finder` searches when dynamically loading libs (f.e. `libopenvino_c.so`).

I downloaded all archives at https://storage.openvinotoolkit.org/repositories/openvino/packages/2025.2/ and unpacked them, making sure that every relevant paths in them was included in the `KNOWN_INSTALLATION_SUBDIRECTORIES` and `KNOWN_BUILD_SUBDIRECTORIES` constants.

Note that haven't bumped the version for a release. Looking at previous commits in `main` that seems the way to go.

Should close https://github.com/intel/openvino-rs/issues/174