### PR TITLE
update install-openvino-action to v11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
           crates/openvino-genai/tests/fixtures/qwen3
           crates/openvino-genai/tests/fixtures/whisper-tiny
           crates/openvino-genai/tests/fixtures/internvl2
-    - uses: abrown/install-openvino-action@8cee80e3ed53c3afdd60ca1907b2ba677f29af8b # v10
+    - uses: abrown/install-openvino-action@3e67f04636745c3a9110bd19f8c8cf7699e59b1d # v11
       with:
         version: ${{ matrix.version }}
         apt: ${{ matrix.apt }}


### PR DESCRIPTION
https://github.com/abrown/install-openvino-action/releases/tag/v11
fixes CI failures for apt install of openvino by this fix https://github.com/abrown/install-openvino-action/commit/3e67f04636745c3a9110bd19f8c8cf7699e59b1d